### PR TITLE
Add AGENTS.md with development environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,37 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Project Overview
+
+Yama is a Java/Kotlin Maven multi-module project implementing a Raft consensus-based distributed service discovery and configuration platform. See `README.md` for a brief description.
+
+### Prerequisites
+
+- **JDK 8** is required (`JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64`). The project targets Java 8 source/target and uses Kotlin 1.3.11, which is incompatible with JDK 16+ due to module access restrictions (Lombok annotation processor fails).
+- **Maven** (`mvn`) must be installed (e.g. `sudo apt-get install -y maven`).
+
+### Build & Test
+
+- Build all modules: `JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64 mvn clean install -DskipTests`
+- Run all tests: `JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64 mvn test`
+- The `RocksDBKeyValueStorageTest` in `yama-common` requires directory `/home/admin/rocksdb/test` to exist with write permissions. Create it before running tests: `sudo mkdir -p /home/admin/rocksdb/test && sudo chmod 777 /home/admin/rocksdb/test`
+- The `ExampleRaftApplicationTests` in `yama-example-raft` starts a Spring Boot app on port 9001. If the app is already running on that port, exclude this module from tests: `mvn test -pl !yama-example-raft`
+
+### Running the Application
+
+The primary runnable application is `yama-example-raft`, a Spring Boot app that demonstrates the Raft KV store:
+
+```
+cd yama-example-raft
+JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64 mvn spring-boot:run
+```
+
+It starts on port 9001 with a single-node Raft cluster. API endpoints:
+- `GET /yama/raft/api/v1/put?key=<key>&value=<value>` — store a key-value pair
+- `GET /yama/raft/api/v1/get?key=<key>` — retrieve a value by key
+
+### Architecture Notes
+
+- No external services (databases, message queues, Docker) are required. RocksDB is embedded via `rocksdbjni`.
+- The project has 7 Maven modules: `yama-common`, `yama-storage`, `yama-messaging`, `yama-raft`, `yama-server` (skeleton), `yama-example` (empty parent), `yama-example-raft` (runnable demo).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Add `AGENTS.md` with Cursor Cloud specific development instructions for the Yama project.

### What's included

- JDK 8 requirement and `JAVA_HOME` configuration (project is incompatible with JDK 16+ due to Lombok/module restrictions)
- Maven build and test commands
- Notes on RocksDB test directory requirement (`/home/admin/rocksdb/test`)
- Port 9001 conflict warning for `yama-example-raft` tests
- Application startup and API usage instructions
- Architecture overview (no external services needed)

### Environment Verification

All 8 Maven modules build and pass tests successfully. The `yama-example-raft` Spring Boot application starts on port 9001 and serves a distributed KV store API via Raft consensus.

**API test results:**
[api_test_output.log](https://cursor.com/agents/bc-78be4790-f1fe-4cb1-ba4e-fe99bdd3c70e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fapi_test_output.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-78be4790-f1fe-4cb1-ba4e-fe99bdd3c70e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-78be4790-f1fe-4cb1-ba4e-fe99bdd3c70e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

