### PR TITLE
Fix KV data loss after restart in yama-example-raft

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Project overview
+
+Yama is a distributed service discovery/configuration platform built on the Raft consensus algorithm. It is a Maven multi-module Java/Kotlin project with 7 modules: `yama-common`, `yama-messaging`, `yama-storage`, `yama-raft`, `yama-server`, `yama-example`, `yama-example-raft`.
+
+### JDK requirement
+
+This project **must** use JDK 8 (`JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64`). JDK 21 (the VM default) causes Lombok/maven-compiler-plugin module-access failures. The `~/.bashrc` is configured with the correct `JAVA_HOME` and `PATH`.
+
+### Build / Test / Run
+
+- **Build**: `mvn clean install -DskipTests` (from repo root)
+- **Test**: `mvn test` (from repo root; all modules)
+- **Run yama-example-raft**: `mvn spring-boot:run -pl yama-example-raft` — starts on port 9001, single-node Raft cluster with KV store API at `/yama/raft/api/v1/put?key=...&value=...` and `/yama/raft/api/v1/get?key=...`
+- **Run yama-server**: Cannot use `mvn spring-boot:run` (plugin version not pinned in parent POM, Maven resolves to latest incompatible version). Instead run via classpath: `java -cp yama-server/target/classes:$(mvn dependency:build-classpath -pl yama-server -Dmdep.outputFile=/dev/stdout -q) com.song.yama.server.YamaServerApplication` — starts on port 8080.
+
+### Gotchas
+
+- The `RocksDBKeyValueStorageTest` in `yama-common` requires `/home/admin/rocksdb/test` directory to exist (hardcoded path). The update script creates this.
+- The `yama-example-raft` module uses its own Spring Boot parent (`spring-boot-starter-parent:2.1.1.RELEASE`) separate from the main parent POM.
+- No external services (databases, message queues, etc.) are required — RocksDB is embedded via JNI.

--- a/yama-example-raft/src/main/java/com/song/yama/example/raft/core/RaftNode.java
+++ b/yama-example-raft/src/main/java/com/song/yama/example/raft/core/RaftNode.java
@@ -167,12 +167,24 @@ public class RaftNode {
             RaftStateRecord raftStateRecord = raftStateRecordResult.getData();
             this.raftStorage.applySnapshot(snapshot);
             this.raftStorage.setHardState(raftStateRecord.getHardState());
+            this.stateMachine.loadSnapshot(snapshot);
             List<Entry> ents = raftStateRecord.getEnts();
             if (CollectionUtils.isNotEmpty(ents)) {
                 this.raftStorage.append(ents);
                 this.lastIndex = ents.get(ents.size() - 1).getIndex();
-            }else {
-                this.stateMachine.loadSnapshot(snapshot);
+            }
+        } else {
+            Result<RaftStateRecord> raftStateRecordResult = this.commitLog.readAll();
+            if (raftStateRecordResult.isSuccess() && raftStateRecordResult.getData() != null) {
+                RaftStateRecord raftStateRecord = raftStateRecordResult.getData();
+                if (raftStateRecord.getHardState() != null) {
+                    this.raftStorage.setHardState(raftStateRecord.getHardState());
+                }
+                List<Entry> ents = raftStateRecord.getEnts();
+                if (CollectionUtils.isNotEmpty(ents)) {
+                    this.raftStorage.append(ents);
+                    this.lastIndex = ents.get(ents.size() - 1).getIndex();
+                }
             }
         }
 
@@ -189,7 +201,8 @@ public class RaftNode {
         raftConfiguration.setMaxSizePerMsg(1024 * 1024);
         raftConfiguration.setMaxInflightMsgs(256);
 //        raftConfiguration.setPreVote(true);
-        if (snapshot != null) {
+        boolean hasExistingState = snapshot != null || this.lastIndex > 0;
+        if (hasExistingState) {
             this.node = new DefaultNode(raftConfiguration);
         } else {
             List<Peer> startPeers = rpeers;
@@ -261,9 +274,6 @@ public class RaftNode {
             // after commit, update appliedIndex
             this.appliedIndex = entry.getIndex();
             log.info("Update appliedIndex:{}.", this.appliedIndex);
-            if (entry.getIndex() == this.lastIndex) {
-                this.stateMachine.loadSnapshot();
-            }
         });
     }
 

--- a/yama-raft/src/main/java/com/song/yama/raft/wal/CommitLog.kt
+++ b/yama-raft/src/main/java/com/song/yama/raft/wal/CommitLog.kt
@@ -52,4 +52,6 @@ interface CommitLog : Closeable {
     fun saveSnap(snapshot: WALRecord.Snapshot): Result<Void>
 
     fun readAll(snapshot: RaftProtoBuf.Snapshot): Result<RaftStateRecord>
+
+    fun readAll(): Result<RaftStateRecord>
 }

--- a/yama-raft/src/main/java/com/song/yama/raft/wal/RocksDBCommitLog.kt
+++ b/yama-raft/src/main/java/com/song/yama/raft/wal/RocksDBCommitLog.kt
@@ -111,18 +111,44 @@ constructor(path: String) : CommitLog {
             if (data == null || data.isEmpty()) {
                 return Result.fail("Snapshot not exist")
             }
-            val snap = Snapshot.newBuilder().mergeFrom(data).build()
-            val term = snap.term
-            var index = snap.index
             val stateBytes = this.keyValueStorage.get(STATE_KEY_PREFIX.toByteArray())
             if (stateBytes == null || stateBytes.size == 0) {
                 return Result.fail("state not exist")
             }
             raftStateRecord.hardState = HardState.newBuilder().mergeFrom(stateBytes).build()
 
+            var index = snapshot.metadata.index
             val entries = ArrayList<Entry>()
             while (true) {
-                val entryBytes = this.keyValueStorage.get(String.format(ENTRY_KEY_PREFIX, term, ++index).toByteArray())
+                val entryBytes = this.keyValueStorage.get(String.format(ENTRY_KEY_PREFIX, ++index).toByteArray())
+                if (entryBytes == null || entryBytes.isEmpty()) {
+                    break
+                }
+                val e = Entry.newBuilder().mergeFrom(entryBytes).build()
+                entries.add(e)
+                this.enti = e.index
+            }
+            raftStateRecord.ents = entries
+        } catch (e: Exception) {
+            log.error("Read from kv storage failed", e)
+            return Result.fail("ReadAll failed :" + e.message)
+        }
+
+        return Result.success(raftStateRecord)
+    }
+
+    override fun readAll(): Result<RaftStateRecord> {
+        val raftStateRecord = RaftStateRecord()
+        try {
+            val stateBytes = this.keyValueStorage.get(STATE_KEY_PREFIX.toByteArray())
+            if (stateBytes != null && stateBytes.isNotEmpty()) {
+                raftStateRecord.hardState = HardState.newBuilder().mergeFrom(stateBytes).build()
+            }
+
+            var index = 0L
+            val entries = ArrayList<Entry>()
+            while (true) {
+                val entryBytes = this.keyValueStorage.get(String.format(ENTRY_KEY_PREFIX, ++index).toByteArray())
                 if (entryBytes == null || entryBytes.isEmpty()) {
                     break
                 }
@@ -160,7 +186,7 @@ constructor(path: String) : CommitLog {
 
     private fun saveEntry(entry: Entry): Result<Void> {
         try {
-            this.keyValueStorage.put(String.format(ENTRY_KEY_PREFIX, entry.term, entry.index).toByteArray(),
+            this.keyValueStorage.put(String.format(ENTRY_KEY_PREFIX, entry.index).toByteArray(),
                     entry.toByteArray())
         } catch (e: IOException) {
             log.error("Save entry failed :$entry", e)
@@ -174,7 +200,7 @@ constructor(path: String) : CommitLog {
 
         private val log = LoggerFactory.getLogger(RocksDBCommitLog::class.java)
 
-        private const val ENTRY_KEY_PREFIX = "record-entry-%d-%d"
+        private const val ENTRY_KEY_PREFIX = "record-entry-%d"
 
         private const val STATE_KEY_PREFIX = "record-state"
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

修复 yama-example-raft 重启后 KV 数据丢失的问题。

### Bug 根因

共发现 3 个导致数据丢失的 bug：

**Bug 1 — 无快照时不读 WAL**：`RaftNode.start()` 只在快照文件存在时才读取 WAL 日志。当写入条目数 < `snapCount`（10）时没有快照文件，节点重启后完全从零开始，所有 KV 数据丢失。

**Bug 2 — `readAll()` 用快照的 term 遍历 entries**：条目以 `record-entry-{term}-{index}` 为 key 存储，但 `readAll()` 用快照的固定 term 遍历所有条目。当发生 leader 选举（term 变化）后，新 term 的条目无法被找到。

**Bug 3 — 状态机恢复顺序错误**：当快照和 WAL entries 同时存在时，快照数据没有先加载到状态机中。entries 在空状态上重放后，`publishEntries` 中 `lastIndex` 处的 `loadSnapshot()` 又用过时的快照数据覆盖了重放结果。

### Fix

| 文件 | 修改 |
|------|------|
| `RocksDBCommitLog.kt` | Entry key 格式从 `record-entry-{term}-{index}` 改为 `record-entry-{index}`（index only）；新增无参 `readAll()` 方法 |
| `CommitLog.kt` | 接口新增 `readAll(): Result<RaftStateRecord>` |
| `RaftNode.java` | 无快照时也读取 WAL；有快照时先加载快照到状态机再重放 entries；移除 `publishEntries` 中错误的 `loadSnapshot()` 调用 |

### 验证

[kv_restart_verification.log](https://cursor.com/agents/bc-a6bb2333-4ca2-4d7c-8160-c1fe449c5b62/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fkv_restart_verification.log)

测试覆盖 3 种恢复路径：
1. 仅 WAL 恢复（无快照）✅
2. 快照 + WAL entries 恢复 ✅
3. 多次重启累积数据 ✅


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a6bb2333-4ca2-4d7c-8160-c1fe449c5b62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a6bb2333-4ca2-4d7c-8160-c1fe449c5b62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

