### PR TITLE
补充 KV Raft 故障测试并修复恢复相关问题

### DIFF
--- a/docs/kv-raft-fault-testing.md
+++ b/docs/kv-raft-fault-testing.md
@@ -29,6 +29,7 @@ Client ──GET /put,/get──► ApiController
 | WAL 持久化 | `yama-raft` | `RocksDBCommitLogRecoveryTest` | 空 WAL、跨 term 条目、快照+增量条目、index-only key |
 | KV 状态机 | `yama-example-raft` | `KVStateMachineTest` | JSON 编解码、快照往返、ConfChange 忽略 |
 | 多节点故障 | `yama-example-raft` | `KvRaftFaultTest` | 复制、分区、Leader 切换、少数派、日志收敛 |
+| **集成故障（HTTP）** | `yama-example-raft` | `RaftKvFaultIntegrationTest` | 真实三节点 Spring Boot、Leader 宕机、网络分区、Follower 追赶 |
 | 端到端重启 | `yama-example-raft` | `RaftKvRecoveryIntegrationTest` | 仅 WAL 重启、快照后重启 |
 | Raft 协议 | `yama-raft` | `RaftFaultInjectionTest` | 非对称丢包、少数派、旧 Leader 重入（库层） |
 
@@ -74,6 +75,29 @@ Leader → Follower 链路断开时，新写入只在 Leader 本地提交（若�
 
 写入 > 10 条触发快照后重启，快照基础数据 + WAL 增量条目均正确恢复。
 
+## 集成故障测试（`RaftKvFaultIntegrationTest`）
+
+基于真实 Spring Boot 三节点集群，通过 HTTP API 验证故障行为。测试基础设施：
+
+- `RaftKvClusterHarness` — 启动 3 个 Spring Boot 实例，动态分配端口
+- `FaultInjectingHttpMessagingService` — 可注入网络丢包/隔离（`integration-fault-test` profile）
+- `FaultInjectionRegistry` — 跨节点共享的故障规则
+
+| 用例 | 场景 |
+|------|------|
+| `threeNodeHttpReplication` | HTTP 写入 Leader，三节点 GET 一致 |
+| `writeOnLeaderReadableOnFollowers` | Follower 可读 Leader 写入 |
+| `leaderCrashFailoverAndContinueWrite` | 停止 Leader 进程，剩余节点选主并继续写入 |
+| `crashedFollowerCatchesUpOnRestart` | Follower 宕机期间写入，重启后追赶日志 |
+| `networkPartitionMakesFollowerStaleUntilHeal` | 隔离 Follower，验证过期读，恢复后收敛 |
+| `isolatedOldLeaderMajorityReElects` | 隔离旧 Leader，多数派重新选主 |
+| `manyWritesConsistentAcrossThreeNodes` | 12 次 HTTP 写入三节点一致 |
+
+```bash
+# 仅集成故障测试（约 1 分钟，每个用例独立 JVM）
+mvn test -pl yama-example-raft -Dtest=RaftKvFaultIntegrationTest
+```
+
 ## 测试基础设施
 
 ### `KvRaftCluster`（内存模拟）
@@ -113,6 +137,7 @@ com.song.yama.raft.servers=127.0.0.1:9001
 |------|------|------|
 | 无快照重启时状态机未同步回放 WAL | `RaftNode.start()` | 新增 `replayEntriesToStateMachine()`，启动时直接回放 |
 | `publishSnapshot` 从磁盘重载而非使用传入快照 | `RaftNode.publishSnapshot()` | 改为 `loadSnapshot(snapshotToSave)` |
+| 节点关闭时 RocksDB JNI 崩溃 | `RaftNode.close()` | 先停止线程池再关闭 WAL；ReadyProcessor 检查 `running` |
 | 多快照文件时加载旧快照 | `SimpleSnapshotStorage.load()` | 按 index 取最新快照 |
 | 测试数据目录不可配置 | `RaftProperties` | 新增 `com.song.yama.raft.data-dir` 配置项 |
 
@@ -168,7 +193,9 @@ mvn spring-boot:run -pl yama-example-raft \
 
 | 文件 | 说明 |
 |------|------|
-| `yama-example-raft/.../KvRaftFaultTest.java` | 多节点故障测试 |
+| `yama-example-raft/.../KvRaftFaultTest.java` | 多节点故障测试（内存模拟） |
+| `yama-example-raft/.../RaftKvFaultIntegrationTest.java` | 集成故障测试（真实 HTTP 三节点） |
+| `yama-example-raft/.../support/RaftKvClusterHarness.java` | 三节点 Spring Boot 集群管理 |
 | `yama-example-raft/.../RaftKvRecoveryIntegrationTest.java` | 重启恢复集成测试 |
 | `yama-example-raft/.../support/KvRaftCluster.java` | 内存集群模拟器 |
 | `yama-raft/.../RocksDBCommitLogRecoveryTest.kt` | WAL 恢复单元测试 |

--- a/docs/kv-raft-fault-testing.md
+++ b/docs/kv-raft-fault-testing.md
@@ -1,0 +1,175 @@
+# KV 基于 Raft 故障测试指南
+
+本文档说明 `yama-example-raft` 分布式 KV 示例的故障测试体系、已修复问题及运行方式。
+
+## 架构概览
+
+```
+Client ──GET /put,/get──► ApiController
+                              │
+                              ▼
+                        kVStateMachine (ConcurrentHashMap)
+                              │ propose(JSON)
+                              ▼
+                          RaftNode
+                    ┌─────────┼─────────┐
+                    ▼         ▼         ▼
+              RocksDB WAL   HTTP RPC   Snapshot
+              (持久化)    (节点间)    (日志压缩)
+```
+
+- **写入**：`put` 将 KV 编码为 JSON 提案提交给 Raft Leader，异步返回 `ok`
+- **读取**：`get` 直接读本地内存，不经过 `readIndex`（可能读到过期数据）
+- **持久化**：`ReadyProcessor` 循环处理 `pullReady()`，写 WAL、复制、应用到状态机
+
+## 测试分层
+
+| 层级 | 模块 | 测试类 | 覆盖场景 |
+|------|------|--------|----------|
+| WAL 持久化 | `yama-raft` | `RocksDBCommitLogRecoveryTest` | 空 WAL、跨 term 条目、快照+增量条目、index-only key |
+| KV 状态机 | `yama-example-raft` | `KVStateMachineTest` | JSON 编解码、快照往返、ConfChange 忽略 |
+| 多节点故障 | `yama-example-raft` | `KvRaftFaultTest` | 复制、分区、Leader 切换、少数派、日志收敛 |
+| 端到端重启 | `yama-example-raft` | `RaftKvRecoveryIntegrationTest` | 仅 WAL 重启、快照后重启 |
+| Raft 协议 | `yama-raft` | `RaftFaultInjectionTest` | 非对称丢包、少数派、旧 Leader 重入（库层） |
+
+## 故障场景与测试用例
+
+### 1. 三节点正常复制 (`threeNodeReplication`)
+
+Leader 写入后，所有节点 KV 一致。
+
+### 2. 非对称丢包阻断复制 (`asymmetricDropBlocksReplication`)
+
+Leader → Follower 链路断开时，新写入只在 Leader 本地提交（若无法形成 quorum 则不会提交），Follower 读不到新数据。
+
+### 3. 分区恢复后收敛 (`partitionHealKvConverges`)
+
+分区期间写入在恢复后通过日志复制同步到所有节点。
+
+### 4. Leader 故障切换 (`leaderFailoverPreservesWrites`)
+
+旧 Leader 被隔离后，新 Leader 选举成功，历史数据保留且新写入可继续。
+
+### 5. 少数派无法选举 (`minorityPartitionCannotElectLeader`)
+
+5 节点集群中 {4,5} 与多数派隔离后无法产生 Leader。
+
+### 6. 旧 Leader 重入 (`oldLeaderRejoinsAndKvConverges`)
+
+被隔离的旧 Leader 重新加入后，日志与 KV 与当前 Leader 收敛，集群仍只有一个 Leader。
+
+### 7. 大量写入一致性 (`manyWritesStayConsistent`)
+
+15 次连续写入（超过默认快照阈值 10），所有节点数据一致。
+
+### 8. Follower 过期读 (`followerReadMayBeStaleBeforeSync`)
+
+被隔离的 Follower 无法收到新写入，可读到隔离前的旧数据，读不到新 key——说明 `get` 是本地读，不保证线性一致。
+
+### 9. WAL 仅恢复 (`walOnlyRestartPreservesKv`)
+
+写入 < 10 条（不触发快照），进程重启后数据完整保留。
+
+### 10. 快照恢复 (`snapshotRestartPreservesKv`)
+
+写入 > 10 条触发快照后重启，快照基础数据 + WAL 增量条目均正确恢复。
+
+## 测试基础设施
+
+### `KvRaftCluster`（内存模拟）
+
+位于 `yama-example-raft/src/test/.../support/`，提供：
+
+- `newCluster(n)` — 创建 n 节点内存集群
+- `electLeader(id)` / `put(id, key, val)` / `sync()`
+- `drop(from, to, rate)` / `cut(a, b)` / `isolate(id)` / `recover()`
+- `assertKvConsistent(key, expected)` — 断言所有节点 KV 一致
+
+不依赖 Spring Boot 和 HTTP，测试速度快、确定性强。
+
+### 端到端重启测试
+
+`RaftKvRecoveryIntegrationTest` 通过 `SpringApplication` 启动真实应用：
+
+```properties
+com.song.yama.raft.data-dir=/tmp/yama-test-xxx   # 隔离测试数据目录
+com.song.yama.raft.id=1
+com.song.yama.raft.servers=127.0.0.1:9001
+```
+
+流程：启动 → 等待 Leader 选举 → 写入 → 关闭 → 再启动 → 验证。
+
+## 已修复问题
+
+### 历史问题（详见 `docs/bugfix-kv-data-loss-after-restart.md`）
+
+1. 无快照时不读 WAL
+2. WAL 条目 key 绑定 term 导致跨 term 丢失
+3. 快照与 WAL 回放顺序错误
+
+### 本次修复
+
+| 问题 | 位置 | 修复 |
+|------|------|------|
+| 无快照重启时状态机未同步回放 WAL | `RaftNode.start()` | 新增 `replayEntriesToStateMachine()`，启动时直接回放 |
+| `publishSnapshot` 从磁盘重载而非使用传入快照 | `RaftNode.publishSnapshot()` | 改为 `loadSnapshot(snapshotToSave)` |
+| 多快照文件时加载旧快照 | `SimpleSnapshotStorage.load()` | 按 index 取最新快照 |
+| 测试数据目录不可配置 | `RaftProperties` | 新增 `com.song.yama.raft.data-dir` 配置项 |
+
+## 运行测试
+
+```bash
+# 全量测试
+mvn test
+
+# 仅 KV 故障测试
+mvn test -pl yama-example-raft -Dtest=KvRaftFaultTest,KVStateMachineTest,RaftKvRecoveryIntegrationTest
+
+# 仅 WAL 恢复测试
+mvn test -pl yama-raft -Dtest=RocksDBCommitLogRecoveryTest
+
+# 手动验证（单节点）
+mvn spring-boot:run -pl yama-example-raft
+curl "http://localhost:9001/yama/raft/api/v1/put?key=name&value=alice"
+curl "http://localhost:9001/yama/raft/api/v1/get?key=name"
+# 重启后再次 get，应返回 alice
+```
+
+## 已知限制与后续改进
+
+| 限制 | 说明 | 建议 |
+|------|------|------|
+| 非线性一致读 | `get` 不经过 `readIndex` | 生产环境应使用 `node.readIndex()` + 等待 appliedIndex |
+| 写入异步确认 | `put` 返回 `ok` 不代表已提交 | 客户端应轮询或使用回调/版本号 |
+| HTTP 消息静默失败 | `HttpMessagingService` 吞掉 IO 异常 | 应上报 `reportUnreachable` 触发 Raft 重试 |
+| 单节点需等待选举 | 启动后需等待 ~1s 才有 Leader | 可在启动后自动 `campaign()` |
+| `preVote` 未启用 | 注释掉了 `setPreVote(true)` | 可减少分区恢复时的无效选举 |
+
+## 多节点手动故障演练
+
+```bash
+# 终端 1
+mvn spring-boot:run -pl yama-example-raft \
+  -Dspring-boot.run.arguments="--server.port=9001 --com.song.yama.raft.id=1 --com.song.yama.raft.servers=127.0.0.1:9001;127.0.0.1:9002;127.0.0.1:9003"
+
+# 终端 2
+mvn spring-boot:run -pl yama-example-raft \
+  -Dspring-boot.run.arguments="--server.port=9002 --com.song.yama.raft.id=2 --com.song.yama.raft.servers=127.0.0.1:9001;127.0.0.1:9002;127.0.0.1:9003"
+
+# 终端 3
+mvn spring-boot:run -pl yama-example-raft \
+  -Dspring-boot.run.arguments="--server.port=9003 --com.song.yama.raft.id=3 --com.song.yama.raft.servers=127.0.0.1:9001;127.0.0.1:9002;127.0.0.1:9003"
+
+# 写入后分别在三个节点 get，验证一致性
+# 使用 iptables 或断开网络模拟分区（需在真实环境操作）
+```
+
+## 相关文件
+
+| 文件 | 说明 |
+|------|------|
+| `yama-example-raft/.../KvRaftFaultTest.java` | 多节点故障测试 |
+| `yama-example-raft/.../RaftKvRecoveryIntegrationTest.java` | 重启恢复集成测试 |
+| `yama-example-raft/.../support/KvRaftCluster.java` | 内存集群模拟器 |
+| `yama-raft/.../RocksDBCommitLogRecoveryTest.kt` | WAL 恢复单元测试 |
+| `docs/bugfix-kv-data-loss-after-restart.md` | 历史数据丢失修复记录 |

--- a/yama-example-raft/pom.xml
+++ b/yama-example-raft/pom.xml
@@ -64,6 +64,14 @@
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <reuseForks>false</reuseForks>
+          <argLine>-Xmx768m</argLine>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/yama-example-raft/src/main/java/com/song/yama/example/raft/core/RaftNode.java
+++ b/yama-example-raft/src/main/java/com/song/yama/example/raft/core/RaftNode.java
@@ -148,9 +148,12 @@ public class RaftNode {
         this.id = this.raftProperties.getId();
         this.peers = new ArrayList<>(Arrays.asList(this.raftProperties.getServers().split(";")));
         this.join = this.raftProperties.isJoin();
-        this.waldir = String.format(System.getProperty("user.home") + "/yama/data/rocksdb/wal-%d", id);
+        String dataBase = StringUtils.isNotBlank(this.raftProperties.getDataDir())
+            ? this.raftProperties.getDataDir()
+            : System.getProperty("user.home") + "/yama/data";
+        this.waldir = String.format(dataBase + "/rocksdb/wal-%d", id);
         FileUtils.forceMkdir(new File(this.waldir));
-        this.snapdir = String.format(System.getProperty("user.home") + "/yama/data/snap-%d", id);
+        this.snapdir = String.format(dataBase + "/snap-%d", id);
         FileUtils.forceMkdir(new File(this.snapdir));
 
         this.snapshotStorage = new SimpleSnapshotStorage(snapdir);
@@ -184,6 +187,7 @@ public class RaftNode {
                 if (CollectionUtils.isNotEmpty(ents)) {
                     this.raftStorage.append(ents);
                     this.lastIndex = ents.get(ents.size() - 1).getIndex();
+                    replayEntriesToStateMachine(ents);
                 }
             }
         }
@@ -277,6 +281,17 @@ public class RaftNode {
         });
     }
 
+    private void replayEntriesToStateMachine(List<Entry> entries) {
+        entries.forEach(entry -> {
+            if (entry.getType() == EntryType.EntryNormal) {
+                if (entry.getData() != null && !entry.getData().isEmpty()) {
+                    this.stateMachine.processCommits(entry.getData().toStringUtf8());
+                }
+            }
+            this.appliedIndex = entry.getIndex();
+        });
+    }
+
     private void publishSnapshot(Snapshot snapshotToSave) {
         if (Utils.INSTANCE.isEmptySnap(snapshotToSave)) {
             return;
@@ -287,7 +302,7 @@ public class RaftNode {
                 snapshotToSave.getMetadata().getIndex(), this.appliedIndex));
         }
 
-        this.stateMachine.loadSnapshot();
+        this.stateMachine.loadSnapshot(snapshotToSave);
         this.confState = snapshotToSave.getMetadata().getConfState();
         this.snapshotIndex = snapshotToSave.getMetadata().getIndex();
         this.appliedIndex = snapshotToSave.getMetadata().getIndex();

--- a/yama-example-raft/src/main/java/com/song/yama/example/raft/core/RaftNode.java
+++ b/yama-example-raft/src/main/java/com/song/yama/example/raft/core/RaftNode.java
@@ -374,8 +374,14 @@ public class RaftNode {
     @PreDestroy
     public void close() throws IOException {
         running = false;
+        this.scheduledExecutorService.shutdownNow();
+        this.taskThreadPool.shutdownNow();
+        try {
+            this.taskThreadPool.awaitTermination(5, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
         this.commitLog.close();
-        this.taskThreadPool.shutdown();
     }
 
     public class ReadyProcessor implements Runnable {
@@ -388,7 +394,7 @@ public class RaftNode {
 
         @Override
         public void run() {
-            while (true) {
+            while (raftNode.running) {
                 try {
                     Ready ready = raftNode.node.pullReady();
                     raftNode.commitLog.save(ready.getHardState(), ready.getCommittedEntries());

--- a/yama-example-raft/src/main/java/com/song/yama/example/raft/network/support/HttpMessagingService.java
+++ b/yama-example-raft/src/main/java/com/song/yama/example/raft/network/support/HttpMessagingService.java
@@ -34,10 +34,12 @@ import okhttp3.RequestBody;
 import okhttp3.Response;
 import org.apache.commons.collections4.CollectionUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
+@Profile("!integration-fault-test")
 public class HttpMessagingService implements MessagingService {
 
     public static final MediaType JSON

--- a/yama-example-raft/src/main/java/com/song/yama/example/raft/properties/RaftProperties.java
+++ b/yama-example-raft/src/main/java/com/song/yama/example/raft/properties/RaftProperties.java
@@ -32,4 +32,9 @@ public class RaftProperties {
     private String servers;
 
     private boolean join;
+
+    /**
+     * Optional base directory for WAL and snapshot data. Defaults to {@code ~/yama/data} when unset.
+     */
+    private String dataDir;
 }

--- a/yama-example-raft/src/main/java/com/song/yama/example/raft/storage/impl/SimpleSnapshotStorage.java
+++ b/yama-example-raft/src/main/java/com/song/yama/example/raft/storage/impl/SimpleSnapshotStorage.java
@@ -58,19 +58,24 @@ public class SimpleSnapshotStorage implements SnapshotStorage {
     @Override
     public Snapshot load() {
         List<String> names = names();
+        Snapshot latest = null;
         for (String s : names) {
             String path = directory.concat("/").concat(s);
             try {
                 byte[] data = Files.toByteArray(new File(path));
                 if (data != null && data.length > 0) {
-                    return Snapshot.newBuilder().mergeFrom(data).build();
+                    Snapshot snapshot = Snapshot.newBuilder().mergeFrom(data).build();
+                    if (latest == null
+                        || snapshot.getMetadata().getIndex() > latest.getMetadata().getIndex()) {
+                        latest = snapshot;
+                    }
                 }
             } catch (IOException e) {
                 log.warn("Failed to read snap file:" + path, e);
                 throw new RaftException("Failed to read snap", e);
             }
         }
-        return null;
+        return latest;
     }
 
     @Override

--- a/yama-example-raft/src/test/java/com/song/yama/example/raft/KVStateMachineTest.java
+++ b/yama-example-raft/src/test/java/com/song/yama/example/raft/KVStateMachineTest.java
@@ -1,0 +1,73 @@
+package com.song.yama.example.raft;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import com.alibaba.fastjson.JSONObject;
+import com.song.yama.example.raft.support.TestKvStateMachine;
+import com.song.yama.raft.protobuf.RaftProtoBuf.Entry;
+import com.song.yama.raft.protobuf.RaftProtoBuf.EntryType;
+import com.song.yama.raft.protobuf.RaftProtoBuf.Snapshot;
+import com.song.yama.raft.protobuf.RaftProtoBuf.SnapshotMetadata;
+import org.junit.Test;
+
+public class KVStateMachineTest {
+
+    @Test
+    public void processCommitsAndLookup() {
+        TestKvStateMachine sm = new TestKvStateMachine();
+        sm.processCommits("{\"key\":\"k\",\"value\":\"v\"}");
+        assertEquals("v", sm.lookup("k"));
+    }
+
+    @Test
+    public void snapshotRoundTrip() {
+        TestKvStateMachine sm = new TestKvStateMachine();
+        sm.processCommits("{\"key\":\"a\",\"value\":\"1\"}");
+        sm.processCommits("{\"key\":\"b\",\"value\":\"2\"}");
+
+        byte[] data = sm.getSnapshot();
+        Snapshot snapshot = Snapshot.newBuilder()
+            .setMetadata(SnapshotMetadata.newBuilder().setIndex(5).setTerm(2).build())
+            .setData(com.google.protobuf.ByteString.copyFrom(data))
+            .build();
+
+        TestKvStateMachine restored = new TestKvStateMachine();
+        restored.loadSnapshot(snapshot);
+        assertEquals("1", restored.lookup("a"));
+        assertEquals("2", restored.lookup("b"));
+    }
+
+    @Test
+    public void applyEntryIgnoresConfChange() {
+        TestKvStateMachine sm = new TestKvStateMachine();
+        Entry confEntry = Entry.newBuilder()
+            .setType(EntryType.EntryConfChange)
+            .setIndex(1)
+            .setTerm(1)
+            .build();
+        sm.applyEntry(confEntry);
+        assertEquals(0, sm.size());
+    }
+
+    @Test
+    public void loadNullSnapshotIsNoOp() {
+        TestKvStateMachine sm = new TestKvStateMachine();
+        sm.processCommits("{\"key\":\"x\",\"value\":\"y\"}");
+        sm.loadSnapshot(null);
+        assertEquals("y", sm.lookup("x"));
+    }
+
+    @Test
+    public void jsonFormatMatchesApplication() {
+        JSONObject json = new JSONObject();
+        json.put("key", "name");
+        json.put("value", "alice");
+        TestKvStateMachine sm = new TestKvStateMachine();
+        sm.processCommits(json.toJSONString());
+        assertNotNull(sm.lookup("name"));
+        assertNull(sm.lookup("missing"));
+    }
+}

--- a/yama-example-raft/src/test/java/com/song/yama/example/raft/KvRaftFaultTest.java
+++ b/yama-example-raft/src/test/java/com/song/yama/example/raft/KvRaftFaultTest.java
@@ -1,0 +1,150 @@
+package com.song.yama.example.raft;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import com.song.yama.example.raft.support.KvRaftCluster;
+import com.song.yama.example.raft.support.KvRaftTestNode;
+import com.song.yama.example.raft.support.TestKvStateMachine;
+import org.junit.Test;
+
+public class KvRaftFaultTest {
+
+    @Test
+    public void threeNodeReplication() {
+        KvRaftCluster cluster = KvRaftCluster.newCluster(3);
+        cluster.electLeader(1);
+        cluster.put(1, "name", "alice");
+        cluster.sync();
+        cluster.assertKvConsistent("name", "alice");
+    }
+
+    @Test
+    public void asymmetricDropBlocksReplication() {
+        KvRaftCluster cluster = KvRaftCluster.newCluster(3);
+        cluster.electLeader(1);
+        cluster.put(1, "seed", "v0");
+        cluster.sync();
+
+        cluster.drop(1, 2, 2.0f);
+        cluster.drop(1, 3, 2.0f);
+        cluster.put(1, "blocked", "yes");
+        cluster.sync();
+
+        assertEquals("yes", cluster.node(1).getKv().lookup("blocked"));
+        assertNull(cluster.node(2).getKv().lookup("blocked"));
+        assertNull(cluster.node(3).getKv().lookup("blocked"));
+    }
+
+    @Test
+    public void partitionHealKvConverges() {
+        KvRaftCluster cluster = KvRaftCluster.newCluster(3);
+        cluster.electLeader(1);
+
+        cluster.drop(1, 2, 2.0f);
+        cluster.drop(1, 3, 2.0f);
+        cluster.put(1, "during", "partition");
+        cluster.sync();
+
+        cluster.recover();
+        cluster.heartbeat(1);
+        cluster.put(1, "after", "heal");
+        cluster.sync();
+
+        cluster.assertKvConsistent("during", "partition");
+        cluster.assertKvConsistent("after", "heal");
+    }
+
+    @Test
+    public void leaderFailoverPreservesWrites() {
+        KvRaftCluster cluster = KvRaftCluster.newCluster(3);
+        cluster.electLeader(1);
+        cluster.put(1, "k1", "v1");
+        cluster.sync();
+
+        cluster.isolate(1);
+        cluster.electLeader(2);
+        cluster.put(2, "k2", "v2");
+        cluster.sync();
+
+        assertEquals("v1", cluster.node(2).getKv().lookup("k1"));
+        assertEquals("v2", cluster.node(2).getKv().lookup("k2"));
+        assertEquals("v2", cluster.node(3).getKv().lookup("k2"));
+    }
+
+    @Test
+    public void minorityPartitionCannotElectLeader() {
+        KvRaftCluster cluster = KvRaftCluster.newCluster(5);
+        cluster.electLeader(1);
+
+        cluster.cut(4, 1);
+        cluster.cut(4, 2);
+        cluster.cut(4, 3);
+        cluster.cut(5, 1);
+        cluster.cut(5, 2);
+        cluster.cut(5, 3);
+
+        cluster.electLeader(4);
+        cluster.electLeader(5);
+
+        assertNotEquals(4L, cluster.leaderId());
+        assertNotEquals(5L, cluster.leaderId());
+    }
+
+    @Test
+    public void oldLeaderRejoinsAndKvConverges() {
+        KvRaftCluster cluster = KvRaftCluster.newCluster(3);
+        cluster.electLeader(1);
+        cluster.put(1, "a", "1");
+        cluster.sync();
+
+        cluster.isolate(1);
+        cluster.electLeader(2);
+        cluster.put(2, "b", "2");
+        cluster.sync();
+
+        cluster.recover();
+        cluster.heartbeat(2);
+        cluster.sync();
+
+        cluster.assertKvConsistent("a", "1");
+        cluster.assertKvConsistent("b", "2");
+        long leaders = java.util.Arrays.stream(new long[]{1, 2, 3})
+            .filter(id -> cluster.node(id).isLeader())
+            .count();
+        assertEquals(1, leaders);
+    }
+
+    @Test
+    public void manyWritesStayConsistent() {
+        KvRaftCluster cluster = KvRaftCluster.newCluster(3);
+        cluster.electLeader(1);
+        for (int i = 0; i < 15; i++) {
+            cluster.put(1, "key-" + i, "value-" + i);
+        }
+        cluster.sync();
+        for (int i = 0; i < 15; i++) {
+            cluster.assertKvConsistent("key-" + i, "value-" + i);
+        }
+        assertTrue(cluster.node(1).getKv().size() >= 15);
+    }
+
+    @Test
+    public void followerReadMayBeStaleBeforeSync() {
+        KvRaftCluster cluster = KvRaftCluster.newCluster(3);
+        cluster.electLeader(1);
+        cluster.put(1, "synced", "yes");
+        cluster.sync();
+
+        cluster.isolate(2);
+        cluster.put(1, "newkey", "newval");
+        cluster.sync();
+
+        assertEquals("newval", cluster.node(1).getKv().lookup("newkey"));
+        assertEquals("newval", cluster.node(3).getKv().lookup("newkey"));
+        assertNull(cluster.node(2).getKv().lookup("newkey"));
+        assertEquals("yes", cluster.node(2).getKv().lookup("synced"));
+    }
+}

--- a/yama-example-raft/src/test/java/com/song/yama/example/raft/RaftKvFaultIntegrationTest.java
+++ b/yama-example-raft/src/test/java/com/song/yama/example/raft/RaftKvFaultIntegrationTest.java
@@ -1,0 +1,167 @@
+package com.song.yama.example.raft;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+
+import com.song.yama.example.raft.support.FaultInjectionRegistry;
+import com.song.yama.example.raft.support.RaftKvClusterHarness;
+import com.song.yama.example.raft.support.RaftKvHttpClient;
+import org.junit.After;
+import org.junit.Test;
+
+/**
+ * Integration fault tests using real Spring Boot nodes and HTTP APIs.
+ */
+public class RaftKvFaultIntegrationTest {
+
+    private RaftKvClusterHarness cluster;
+    private final RaftKvHttpClient client = new RaftKvHttpClient();
+
+    @After
+    public void cleanup() {
+        if (cluster != null) {
+            cluster.close();
+            cluster = null;
+        }
+    }
+
+    @Test
+    public void threeNodeHttpReplication() throws Exception {
+        cluster = RaftKvClusterHarness.startThreeNodeCluster();
+        cluster.putOnLeader(client, "name", "alice");
+    }
+
+    @Test
+    public void writeOnLeaderReadableOnFollowers() throws Exception {
+        cluster = RaftKvClusterHarness.startThreeNodeCluster();
+        int leaderId = cluster.leaderId();
+        cluster.putOnLeader(client, "city", "beijing");
+
+        for (int id = 1; id <= 3; id++) {
+            if (id != leaderId) {
+                assertEquals("beijing", client.get(cluster.node(id).getPort(), "city"));
+            }
+        }
+    }
+
+    @Test
+    public void leaderCrashFailoverAndContinueWrite() throws Exception {
+        cluster = RaftKvClusterHarness.startThreeNodeCluster();
+        int oldLeaderId = cluster.leaderId();
+        cluster.putOnLeader(client, "before", "crash");
+
+        cluster.stopNode(oldLeaderId);
+        Thread.sleep(3000);
+        cluster.waitForLeader(80);
+
+        int newLeaderId = cluster.leaderId();
+        assertNotEquals(oldLeaderId, newLeaderId);
+        client.put(cluster.leaderPort(), "after", "failover");
+        cluster.assertKvConsistent(client, "after", "failover");
+
+        for (int id = 1; id <= 3; id++) {
+            if (id != oldLeaderId) {
+                assertEquals("crash", client.get(cluster.node(id).getPort(), "before"));
+            }
+        }
+    }
+
+    @Test
+    public void crashedFollowerCatchesUpOnRestart() throws Exception {
+        cluster = RaftKvClusterHarness.startThreeNodeCluster();
+        int followerId = 1;
+        while (followerId == cluster.leaderId()) {
+            followerId++;
+        }
+
+        cluster.stopNode(followerId);
+        client.put(cluster.leaderPort(), "while-down", "value");
+        cluster.assertKvConsistent(client, "while-down", "value");
+
+        cluster.restartNode(followerId);
+        client.waitFor(cluster.node(followerId).getPort(), "while-down", "value", 80);
+    }
+
+    @Test
+    public void networkPartitionMakesFollowerStaleUntilHeal() throws Exception {
+        cluster = RaftKvClusterHarness.startThreeNodeCluster();
+        int leaderId = cluster.leaderId();
+        cluster.putOnLeader(client, "synced", "yes");
+
+        int isolatedId = 1;
+        while (isolatedId == leaderId) {
+            isolatedId++;
+        }
+
+        FaultInjectionRegistry.isolate(isolatedId);
+        client.put(cluster.leaderPort(), "newkey", "newval");
+        Thread.sleep(1500);
+
+        assertEquals("newval", client.get(cluster.leaderPort(), "newkey"));
+        assertNull(client.get(cluster.node(isolatedId).getPort(), "newkey"));
+        assertEquals("yes", client.get(cluster.node(isolatedId).getPort(), "synced"));
+
+        FaultInjectionRegistry.recover();
+        Thread.sleep(2000);
+        client.waitFor(cluster.node(isolatedId).getPort(), "newkey", "newval", 80);
+    }
+
+    @Test
+    public void isolatedOldLeaderMajorityReElects() throws Exception {
+        cluster = RaftKvClusterHarness.startThreeNodeCluster();
+        int oldLeaderId = cluster.leaderId();
+        cluster.putOnLeader(client, "seed", "data");
+
+        FaultInjectionRegistry.isolate(oldLeaderId);
+        Thread.sleep(3000);
+
+        assertEquals(1, cluster.countLeadersExcluding(oldLeaderId));
+        int activeLeaderId = leaderIdExcluding(oldLeaderId);
+        assertNotEquals(oldLeaderId, activeLeaderId);
+
+        client.put(cluster.node(activeLeaderId).getPort(), "majority", "write");
+        for (int id = 1; id <= 3; id++) {
+            if (id != oldLeaderId) {
+                client.waitFor(cluster.node(id).getPort(), "majority", "write", 100);
+            }
+        }
+
+        FaultInjectionRegistry.recover();
+        Thread.sleep(2000);
+        cluster.waitForLeader(80);
+        assertEquals(1, countLeaders());
+    }
+
+    private int leaderIdExcluding(int excludedId) {
+        for (int id = 1; id <= 3; id++) {
+            if (id != excludedId && cluster.node(id).isRunning() && cluster.node(id).isLeader()) {
+                return id;
+            }
+        }
+        return -1;
+    }
+
+    @Test
+    public void manyWritesConsistentAcrossThreeNodes() throws Exception {
+        cluster = RaftKvClusterHarness.startThreeNodeCluster();
+        int leaderPort = cluster.leaderPort();
+        for (int i = 0; i < 12; i++) {
+            client.put(leaderPort, "k" + i, "v" + i);
+        }
+        Thread.sleep(2000);
+        for (int i = 0; i < 12; i++) {
+            cluster.assertKvConsistent(client, "k" + i, "v" + i);
+        }
+    }
+
+    private int countLeaders() {
+        int count = 0;
+        for (int id = 1; id <= 3; id++) {
+            if (cluster.node(id).isRunning() && cluster.node(id).isLeader()) {
+                count++;
+            }
+        }
+        return count;
+    }
+}

--- a/yama-example-raft/src/test/java/com/song/yama/example/raft/RaftKvRecoveryIntegrationTest.java
+++ b/yama-example-raft/src/test/java/com/song/yama/example/raft/RaftKvRecoveryIntegrationTest.java
@@ -1,0 +1,165 @@
+package com.song.yama.example.raft;
+
+import static org.junit.Assert.assertEquals;
+
+import com.song.yama.example.raft.core.RaftNode;
+import com.song.yama.raft.StateType;
+import java.io.File;
+import java.nio.file.Files;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.After;
+import org.junit.Test;
+import org.springframework.boot.SpringApplication;
+import com.song.yama.example.raft.ExampleRaftApplication;
+import org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * End-to-end restart tests: start app, write KV, stop, start again, verify data.
+ */
+public class RaftKvRecoveryIntegrationTest {
+
+    private String dataDir;
+    private ConfigurableApplicationContext context;
+
+    @After
+    public void cleanup() {
+        if (context != null) {
+            context.close();
+        }
+        if (dataDir != null) {
+            deleteRecursively(new File(dataDir));
+        }
+    }
+
+    @Test
+    public void walOnlyRestartPreservesKv() throws Exception {
+        dataDir = Files.createTempDirectory("yama-kv-wal-" + UUID.randomUUID()).toString();
+
+        context = startApp(dataDir);
+        waitForLeader(context);
+        int port = serverPort(context);
+        RestTemplate client = new RestTemplate();
+
+        put(client, port, "name", "alice");
+        put(client, port, "city", "beijing");
+        assertEquals("alice", get(client, port, "name"));
+
+        context.close();
+        context = null;
+        Thread.sleep(300);
+
+        context = startApp(dataDir);
+        waitForLeader(context);
+        port = serverPort(context);
+        client = new RestTemplate();
+
+        assertEquals("alice", get(client, port, "name"));
+        assertEquals("beijing", get(client, port, "city"));
+    }
+
+    @Test
+    public void snapshotRestartPreservesKv() throws Exception {
+        dataDir = Files.createTempDirectory("yama-kv-snap-" + UUID.randomUUID()).toString();
+
+        context = startApp(dataDir);
+        waitForLeader(context);
+        int port = serverPort(context);
+        RestTemplate client = new RestTemplate();
+
+        for (int i = 0; i < 12; i++) {
+            put(client, port, "k" + i, "v" + i);
+        }
+        Thread.sleep(1500);
+
+        assertEquals("v0", get(client, port, "k0"));
+        assertEquals("v11", get(client, port, "k11"));
+
+        context.close();
+        context = null;
+        Thread.sleep(300);
+
+        context = startApp(dataDir);
+        waitForLeader(context);
+        port = serverPort(context);
+        client = new RestTemplate();
+
+        assertEquals("v0", get(client, port, "k0"));
+        assertEquals("v11", get(client, port, "k11"));
+    }
+
+    private static ConfigurableApplicationContext startApp(String dataDir) {
+        SpringApplication app = new SpringApplication(ExampleRaftApplication.class);
+        Map<String, Object> props = new HashMap<>();
+        props.put("server.port", "0");
+        props.put("com.song.yama.raft.id", "1");
+        props.put("com.song.yama.raft.servers", "127.0.0.1:9001");
+        props.put("com.song.yama.raft.join", "false");
+        props.put("com.song.yama.raft.data-dir", dataDir);
+        return app.run(toArgs(props));
+    }
+
+    private static String[] toArgs(Map<String, Object> props) {
+        return props.entrySet().stream()
+            .map(e -> "--" + e.getKey() + "=" + e.getValue())
+            .toArray(String[]::new);
+    }
+
+    private static void waitForLeader(ConfigurableApplicationContext context) throws InterruptedException {
+        RaftNode raftNode = context.getBean(RaftNode.class);
+        for (int i = 0; i < 50; i++) {
+            if (raftNode.getNode().status().getSoftState().getRaftState() == StateType.LEADER) {
+                return;
+            }
+            Thread.sleep(200);
+        }
+        throw new AssertionError("leader not elected within timeout");
+    }
+
+    private static int serverPort(ConfigurableApplicationContext context) {
+        ServletWebServerApplicationContext web = (ServletWebServerApplicationContext) context;
+        return web.getWebServer().getPort();
+    }
+
+    private static void put(RestTemplate client, int port, String key, String value) throws InterruptedException {
+        String body = client.getForObject(
+            "http://127.0.0.1:" + port + "/yama/raft/api/v1/put?key=" + key + "&value=" + value,
+            String.class);
+        assertEquals("ok", body);
+        waitFor(client, port, key, value);
+    }
+
+    private static void waitFor(RestTemplate client, int port, String key, String expected)
+        throws InterruptedException {
+        for (int i = 0; i < 50; i++) {
+            String actual = get(client, port, key);
+            if (expected.equals(actual)) {
+                return;
+            }
+            Thread.sleep(100);
+        }
+        assertEquals(expected, get(client, port, key));
+    }
+
+    private static String get(RestTemplate client, int port, String key) {
+        return client.getForObject(
+            "http://127.0.0.1:" + port + "/yama/raft/api/v1/get?key=" + key,
+            String.class);
+    }
+
+    private static void deleteRecursively(File file) {
+        if (file == null || !file.exists()) {
+            return;
+        }
+        File[] children = file.listFiles();
+        if (children != null) {
+            for (File child : children) {
+                deleteRecursively(child);
+            }
+        }
+        file.delete();
+    }
+}

--- a/yama-example-raft/src/test/java/com/song/yama/example/raft/support/FaultInjectingHttpMessagingService.java
+++ b/yama-example-raft/src/test/java/com/song/yama/example/raft/support/FaultInjectingHttpMessagingService.java
@@ -1,0 +1,93 @@
+package com.song.yama.example.raft.support;
+
+import com.alibaba.fastjson.JSONObject;
+import com.song.yama.example.raft.controller.request.ByteArrayBody;
+import com.song.yama.example.raft.core.RaftNode;
+import com.song.yama.example.raft.network.MessagingService;
+import com.song.yama.raft.protobuf.RaftProtoBuf.Message;
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import org.apache.commons.collections4.CollectionUtils;
+
+/**
+ * HTTP messaging with optional network fault injection for integration tests.
+ */
+@Slf4j
+public class FaultInjectingHttpMessagingService implements MessagingService {
+
+    public static final MediaType JSON = MediaType.parse("application/json; charset=utf-8");
+
+    private final RaftNode raftNode;
+    private final AtomicReference<List<String>> hosts = new AtomicReference<>();
+    private final OkHttpClient okHttpClient = new OkHttpClient.Builder()
+        .readTimeout(6, TimeUnit.SECONDS)
+        .connectTimeout(5, TimeUnit.SECONDS)
+        .writeTimeout(10, TimeUnit.SECONDS)
+        .retryOnConnectionFailure(true)
+        .build();
+
+    public FaultInjectingHttpMessagingService(RaftNode raftNode) {
+        this.raftNode = raftNode;
+    }
+
+    @Override
+    public void start() {
+        this.hosts.set(raftNode.getPeers());
+    }
+
+    @Override
+    public synchronized void send(List<Message> messages) {
+        if (CollectionUtils.isEmpty(this.hosts.get())) {
+            this.hosts.set(raftNode.getPeers());
+        }
+        List<String> peerHosts = this.hosts.get();
+        if (CollectionUtils.isEmpty(peerHosts) || CollectionUtils.isEmpty(messages)) {
+            return;
+        }
+        long localId = raftNode.getId();
+        messages.forEach(message -> {
+            if (message == null || message.getTo() == 0L) {
+                return;
+            }
+            if (FaultInjectionRegistry.shouldDrop(localId, message.getTo())) {
+                log.debug("Fault injection: drop message from {} to {}, type={}",
+                    localId, message.getTo(), message.getType());
+                return;
+            }
+            String host = peerHosts.get((int) (message.getTo() - 1));
+            RequestBody body = RequestBody.create(JSON,
+                JSONObject.toJSONString(new ByteArrayBody(message.toByteArray())));
+            Request request = new Request.Builder()
+                .url(String.format("http://%s/yama/raft/api/v1/send", host))
+                .post(body)
+                .build();
+            try (Response response = okHttpClient.newCall(request).execute()) {
+                log.debug("Send message to host[{}] type:{}.", host, message.getType());
+            } catch (IOException e) {
+                log.debug("Send message to remote failed: {}", host, e);
+            }
+        });
+    }
+
+    @Override
+    public void refreshHosts(List<String> hosts) {
+        for (; ; ) {
+            List<String> oldHosts = this.hosts.get();
+            if (this.hosts.compareAndSet(oldHosts, hosts)) {
+                return;
+            }
+        }
+    }
+
+    @Override
+    public void close() {
+    }
+}

--- a/yama-example-raft/src/test/java/com/song/yama/example/raft/support/FaultInjectionRegistry.java
+++ b/yama-example-raft/src/test/java/com/song/yama/example/raft/support/FaultInjectionRegistry.java
@@ -1,0 +1,73 @@
+package com.song.yama.example.raft.support;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * Shared fault-injection rules across multiple Spring Boot nodes in integration tests.
+ */
+public final class FaultInjectionRegistry {
+
+    private static final Map<Connection, Float> DROP_RATES = new ConcurrentHashMap<>();
+
+    private FaultInjectionRegistry() {
+    }
+
+    public static void drop(long from, long to, float rate) {
+        DROP_RATES.put(new Connection(from, to), rate);
+    }
+
+    public static void cut(long one, long other) {
+        drop(one, other, 2.0f);
+        drop(other, one, 2.0f);
+    }
+
+    public static void isolate(long nodeId) {
+        for (long peer = 1; peer <= 5; peer++) {
+            if (peer != nodeId) {
+                drop(nodeId, peer, 1.0f);
+                drop(peer, nodeId, 1.0f);
+            }
+        }
+    }
+
+    public static void recover() {
+        DROP_RATES.clear();
+    }
+
+    public static boolean shouldDrop(long from, long to) {
+        float rate = DROP_RATES.getOrDefault(new Connection(from, to), 0f);
+        if (rate <= 0f) {
+            return false;
+        }
+        return ThreadLocalRandom.current().nextFloat() < rate;
+    }
+
+    private static final class Connection {
+        private final long from;
+        private final long to;
+
+        private Connection(long from, long to) {
+            this.from = from;
+            this.to = to;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof Connection)) {
+                return false;
+            }
+            Connection that = (Connection) o;
+            return from == that.from && to == that.to;
+        }
+
+        @Override
+        public int hashCode() {
+            return Long.hashCode(from) * 31 + Long.hashCode(to);
+        }
+    }
+}

--- a/yama-example-raft/src/test/java/com/song/yama/example/raft/support/FaultTestConfiguration.java
+++ b/yama-example-raft/src/test/java/com/song/yama/example/raft/support/FaultTestConfiguration.java
@@ -1,0 +1,21 @@
+package com.song.yama.example.raft.support;
+
+import com.song.yama.example.raft.core.RaftNode;
+import com.song.yama.example.raft.network.MessagingService;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
+
+@Profile("integration-fault-test")
+@TestConfiguration
+public class FaultTestConfiguration {
+
+    @Bean
+    @Primary
+    public MessagingService faultInjectingMessagingService(RaftNode raftNode) {
+        FaultInjectingHttpMessagingService service = new FaultInjectingHttpMessagingService(raftNode);
+        service.start();
+        return service;
+    }
+}

--- a/yama-example-raft/src/test/java/com/song/yama/example/raft/support/KvRaftCluster.java
+++ b/yama-example-raft/src/test/java/com/song/yama/example/raft/support/KvRaftCluster.java
@@ -1,0 +1,166 @@
+package com.song.yama.example.raft.support;
+
+import com.song.yama.raft.exception.RaftException;
+import com.song.yama.raft.protobuf.RaftProtoBuf.Message;
+import com.song.yama.raft.protobuf.RaftProtoBuf.MessageType;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/**
+ * In-memory multi-node KV Raft cluster with message loss / partition simulation.
+ */
+public class KvRaftCluster {
+
+    private final Map<Long, KvRaftTestNode> nodes;
+    private final Map<Connection, Float> dropRates = new HashMap<>();
+
+    private KvRaftCluster(Map<Long, KvRaftTestNode> nodes) {
+        this.nodes = nodes;
+    }
+
+    public static KvRaftCluster newCluster(int size) {
+        List<Long> peerIds = IntStream.rangeClosed(1, size).asLongStream().boxed().collect(Collectors.toList());
+        Map<Long, KvRaftTestNode> nodeMap = new HashMap<>();
+        for (Long id : peerIds) {
+            nodeMap.put(id, new KvRaftTestNode(id, peerIds));
+        }
+        return new KvRaftCluster(nodeMap);
+    }
+
+    public KvRaftTestNode node(long id) {
+        return nodes.get(id);
+    }
+
+    public void electLeader(long id) {
+        send(single(Message.newBuilder().setFrom(id).setTo(id).setType(MessageType.MsgHup).build()));
+    }
+
+    public void heartbeat(long leaderId) {
+        send(single(Message.newBuilder().setFrom(leaderId).setTo(leaderId).setType(MessageType.MsgBeat).build()));
+    }
+
+    public void put(long fromNodeId, String key, String value) {
+        nodes.get(fromNodeId).propose(key, value);
+        sync();
+    }
+
+    public void sync() {
+        for (KvRaftTestNode node : nodes.values()) {
+            List<Message> pending = node.drainMessages();
+            if (!pending.isEmpty()) {
+                send(pending);
+            }
+        }
+        nodes.values().forEach(KvRaftTestNode::applyCommitted);
+    }
+
+    public void send(List<Message> messages) {
+        List<Message> queue = new ArrayList<>(messages);
+        while (!queue.isEmpty()) {
+            List<Message> next = new ArrayList<>();
+            for (Message message : queue) {
+                KvRaftTestNode target = nodes.get(message.getTo());
+                if (target == null) {
+                    throw new RaftException(message.getTo() + " doesn't exist");
+                }
+                target.step(message);
+                next.addAll(filter(target.drainMessages()));
+            }
+            queue = next;
+        }
+        nodes.values().forEach(KvRaftTestNode::applyCommitted);
+    }
+
+    public void drop(long from, long to, float rate) {
+        dropRates.put(new Connection(from, to), rate);
+    }
+
+    public void cut(long one, long other) {
+        drop(one, other, 2.0f);
+        drop(other, one, 2.0f);
+    }
+
+    public void isolate(long id) {
+        for (long peerId : nodes.keySet()) {
+            if (peerId != id) {
+                drop(id, peerId, 1.0f);
+                drop(peerId, id, 1.0f);
+            }
+        }
+    }
+
+    public void recover() {
+        dropRates.clear();
+    }
+
+    public long leaderId() {
+        return nodes.values().stream()
+            .filter(KvRaftTestNode::isLeader)
+            .map(KvRaftTestNode::getId)
+            .findFirst()
+            .orElse(-1L);
+    }
+
+    public void assertKvConsistent(String key, String expected) {
+        for (KvRaftTestNode node : nodes.values()) {
+            String actual = node.getKv().lookup(key);
+            if (expected == null ? actual != null : !expected.equals(actual)) {
+                throw new AssertionError(String.format("node %d: key=%s expected=%s actual=%s",
+                    node.getId(), key, expected, actual));
+            }
+        }
+    }
+
+    private List<Message> filter(List<Message> messages) {
+        List<Message> kept = new ArrayList<>();
+        for (Message message : messages) {
+            if (message.getType() == MessageType.MsgHup) {
+                throw new RaftException("unexpected msgHup on the wire");
+            }
+            float rate = dropRates.getOrDefault(new Connection(message.getFrom(), message.getTo()), 0f);
+            if (ThreadLocalRandom.current().nextFloat() < rate) {
+                continue;
+            }
+            kept.add(message);
+        }
+        return kept;
+    }
+
+    private static List<Message> single(Message message) {
+        List<Message> list = new ArrayList<>();
+        list.add(message);
+        return list;
+    }
+
+    private static final class Connection {
+        private final long from;
+        private final long to;
+
+        private Connection(long from, long to) {
+            this.from = from;
+            this.to = to;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof Connection)) {
+                return false;
+            }
+            Connection that = (Connection) o;
+            return from == that.from && to == that.to;
+        }
+
+        @Override
+        public int hashCode() {
+            return Long.hashCode(from) * 31 + Long.hashCode(to);
+        }
+    }
+}

--- a/yama-example-raft/src/test/java/com/song/yama/example/raft/support/KvRaftTestNode.java
+++ b/yama-example-raft/src/test/java/com/song/yama/example/raft/support/KvRaftTestNode.java
@@ -1,0 +1,81 @@
+package com.song.yama.example.raft.support;
+
+import com.google.common.collect.Lists;
+import com.song.yama.raft.MemoryRaftStorage;
+import com.song.yama.raft.Raft;
+import com.song.yama.raft.RaftConfiguration;
+import com.song.yama.raft.StateType;
+import com.song.yama.raft.protobuf.RaftProtoBuf.Entry;
+import com.song.yama.raft.protobuf.RaftProtoBuf.Message;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Single Raft peer with an attached KV state machine for deterministic tests.
+ */
+public class KvRaftTestNode {
+
+    private final long id;
+    private final Raft raft;
+    private final MemoryRaftStorage storage;
+    private final TestKvStateMachine kv;
+
+    public KvRaftTestNode(long id, List<Long> peerIds) {
+        this.id = id;
+        this.storage = new MemoryRaftStorage();
+        RaftConfiguration config = new RaftConfiguration();
+        config.setId(id);
+        config.setPeers(peerIds);
+        config.setElectionTick(10);
+        config.setHeartbeatTick(1);
+        config.setRaftStorage(storage);
+        config.setMaxSizePerMsg(Long.MAX_VALUE);
+        config.setMaxInflightMsgs(256);
+        this.raft = new Raft(config);
+        this.kv = new TestKvStateMachine();
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public Raft getRaft() {
+        return raft;
+    }
+
+    public MemoryRaftStorage getStorage() {
+        return storage;
+    }
+
+    public TestKvStateMachine getKv() {
+        return kv;
+    }
+
+    public boolean isLeader() {
+        return raft.getState() == StateType.LEADER;
+    }
+
+    public void step(Message message) {
+        raft.step(message);
+    }
+
+    public List<Message> drainMessages() {
+        List<Message> msgs = new ArrayList<>(raft.getMsgs());
+        raft.setMsgs(Lists.newArrayList());
+        return msgs;
+    }
+
+    public void applyCommitted() {
+        storage.append(raft.getRaftLog().unstableEntries());
+        raft.getRaftLog().stableTo(raft.getRaftLog().lastIndex(), raft.getRaftLog().lastTerm());
+        List<Entry> entries = raft.getRaftLog().nextEnts();
+        for (Entry entry : entries) {
+            kv.applyEntry(entry);
+        }
+        raft.getRaftLog().appliedTo(raft.getRaftLog().getCommitted());
+    }
+
+    public void propose(String key, String value) {
+        kv.propose(raft, key, value);
+    }
+}

--- a/yama-example-raft/src/test/java/com/song/yama/example/raft/support/RaftKvClusterHarness.java
+++ b/yama-example-raft/src/test/java/com/song/yama/example/raft/support/RaftKvClusterHarness.java
@@ -1,0 +1,234 @@
+package com.song.yama.example.raft.support;
+
+import com.song.yama.example.raft.ExampleRaftApplication;
+import com.song.yama.example.raft.core.RaftNode;
+import com.song.yama.raft.StateType;
+import java.io.File;
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext;
+import org.springframework.context.ConfigurableApplicationContext;
+
+/**
+ * Manages a multi-node Spring Boot Raft KV cluster for integration tests.
+ */
+public final class RaftKvClusterHarness implements AutoCloseable {
+
+    private final String dataDir;
+    private final List<NodeHandle> nodes = new ArrayList<>();
+    private final String servers;
+    private final int[] ports;
+
+    private RaftKvClusterHarness(String dataDir, int[] ports, String servers) {
+        this.dataDir = dataDir;
+        this.ports = ports.clone();
+        this.servers = servers;
+    }
+
+    public static RaftKvClusterHarness startThreeNodeCluster() throws Exception {
+        FaultInjectionRegistry.recover();
+        String dataDir = Files.createTempDirectory("yama-kv-it-" + UUID.randomUUID()).toString();
+        int[] ports = allocatePorts(3);
+        String servers = buildServers(ports);
+        RaftKvClusterHarness harness = new RaftKvClusterHarness(dataDir, ports, servers);
+        for (int id = 1; id <= 3; id++) {
+            harness.bootNode(id);
+        }
+        harness.waitForLeader(80);
+        Thread.sleep(1500);
+        return harness;
+    }
+
+    public void putOnLeader(RaftKvHttpClient client, String key, String value) throws InterruptedException {
+        waitForLeader(80);
+        client.put(leaderPort(), key, value);
+        assertKvConsistent(client, key, value);
+    }
+
+    public NodeHandle node(int id) {
+        return nodes.get(id - 1);
+    }
+
+    public int leaderId() {
+        for (NodeHandle handle : nodes) {
+            if (handle.isRunning() && handle.isLeader()) {
+                return handle.getId();
+            }
+        }
+        return -1;
+    }
+
+    public int leaderPort() {
+        int id = leaderId();
+        if (id < 0) {
+            return -1;
+        }
+        return node(id).getPort();
+    }
+
+    public void waitForLeader(int attempts) throws InterruptedException {
+        for (int i = 0; i < attempts; i++) {
+            if (leaderId() > 0) {
+                return;
+            }
+            Thread.sleep(200);
+        }
+        throw new AssertionError("leader not elected within timeout");
+    }
+
+    public void stopNode(int id) throws InterruptedException {
+        NodeHandle handle = node(id);
+        if (handle.context != null) {
+            handle.context.close();
+            handle.context = null;
+            Thread.sleep(800);
+        }
+    }
+
+    public void restartNode(int id) throws InterruptedException {
+        stopNode(id);
+        bootNode(id);
+        waitForLeader(60);
+        Thread.sleep(500);
+    }
+
+    public void assertKvConsistent(RaftKvHttpClient client, String key, String expected) throws InterruptedException {
+        for (NodeHandle handle : nodes) {
+            if (!handle.isRunning()) {
+                continue;
+            }
+            client.waitFor(handle.getPort(), key, expected, 100);
+        }
+    }
+
+    public int countLeadersExcluding(int excludedId) {
+        int count = 0;
+        for (NodeHandle handle : nodes) {
+            if (handle.isRunning() && handle.getId() != excludedId && handle.isLeader()) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    @Override
+    public void close() {
+        for (NodeHandle handle : nodes) {
+            if (handle.context != null) {
+                handle.context.close();
+            }
+        }
+        deleteRecursively(new File(dataDir));
+        FaultInjectionRegistry.recover();
+    }
+
+    private void bootNode(int id) {
+        NodeHandle handle = new NodeHandle(id, ports[id - 1]);
+        if (nodes.size() >= id) {
+            nodes.set(id - 1, handle);
+        } else {
+            while (nodes.size() < id - 1) {
+                nodes.add(null);
+            }
+            nodes.add(handle);
+        }
+
+        SpringApplication app = new SpringApplication(ExampleRaftApplication.class, FaultTestConfiguration.class);
+        Map<String, Object> props = new HashMap<>();
+        props.put("server.port", String.valueOf(ports[id - 1]));
+        props.put("com.song.yama.raft.id", String.valueOf(id));
+        props.put("com.song.yama.raft.servers", servers);
+        props.put("com.song.yama.raft.join", "false");
+        props.put("com.song.yama.raft.data-dir", dataDir + "/node-" + id);
+        props.put("spring.profiles.active", "integration-fault-test");
+        handle.context = app.run(toArgs(props));
+        handle.port = serverPort(handle.context);
+    }
+
+    private static int[] allocatePorts(int count) throws IOException {
+        int[] ports = new int[count];
+        ServerSocket[] sockets = new ServerSocket[count];
+        try {
+            for (int i = 0; i < count; i++) {
+                sockets[i] = new ServerSocket(0);
+                ports[i] = sockets[i].getLocalPort();
+            }
+            return ports;
+        } finally {
+            for (ServerSocket socket : sockets) {
+                if (socket != null) {
+                    socket.close();
+                }
+            }
+        }
+    }
+
+    private static String buildServers(int[] ports) {
+        return IntStream.of(ports)
+            .mapToObj(port -> "127.0.0.1:" + port)
+            .collect(Collectors.joining(";"));
+    }
+
+    private static String[] toArgs(Map<String, Object> props) {
+        return props.entrySet().stream()
+            .map(e -> "--" + e.getKey() + "=" + e.getValue())
+            .toArray(String[]::new);
+    }
+
+    private static int serverPort(ConfigurableApplicationContext context) {
+        return ((ServletWebServerApplicationContext) context).getWebServer().getPort();
+    }
+
+    private static void deleteRecursively(File file) {
+        if (file == null || !file.exists()) {
+            return;
+        }
+        File[] children = file.listFiles();
+        if (children != null) {
+            for (File child : children) {
+                deleteRecursively(child);
+            }
+        }
+        file.delete();
+    }
+
+    public static final class NodeHandle {
+        private final int id;
+        private int port;
+        private ConfigurableApplicationContext context;
+
+        private NodeHandle(int id, int port) {
+            this.id = id;
+            this.port = port;
+        }
+
+        public int getId() {
+            return id;
+        }
+
+        public int getPort() {
+            return port;
+        }
+
+        public boolean isRunning() {
+            return context != null && context.isActive();
+        }
+
+        public boolean isLeader() {
+            if (!isRunning()) {
+                return false;
+            }
+            RaftNode raftNode = context.getBean(RaftNode.class);
+            return raftNode.getNode().status().getSoftState().getRaftState() == StateType.LEADER;
+        }
+    }
+}

--- a/yama-example-raft/src/test/java/com/song/yama/example/raft/support/RaftKvHttpClient.java
+++ b/yama-example-raft/src/test/java/com/song/yama/example/raft/support/RaftKvHttpClient.java
@@ -1,0 +1,35 @@
+package com.song.yama.example.raft.support;
+
+import static org.junit.Assert.assertEquals;
+
+import org.springframework.web.client.RestTemplate;
+
+public final class RaftKvHttpClient {
+
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    public void put(int port, String key, String value) throws InterruptedException {
+        String body = restTemplate.getForObject(url(port, "/put?key=" + key + "&value=" + value), String.class);
+        assertEquals("ok", body);
+        waitFor(port, key, value, 50);
+    }
+
+    public String get(int port, String key) {
+        return restTemplate.getForObject(url(port, "/get?key=" + key), String.class);
+    }
+
+    public void waitFor(int port, String key, String expected, int attempts) throws InterruptedException {
+        for (int i = 0; i < attempts; i++) {
+            String actual = get(port, key);
+            if (expected == null ? actual == null : expected.equals(actual)) {
+                return;
+            }
+            Thread.sleep(100);
+        }
+        assertEquals(expected, get(port, key));
+    }
+
+    private static String url(int port, String path) {
+        return "http://127.0.0.1:" + port + "/yama/raft/api/v1" + path;
+    }
+}

--- a/yama-example-raft/src/test/java/com/song/yama/example/raft/support/TestKvStateMachine.java
+++ b/yama-example-raft/src/test/java/com/song/yama/example/raft/support/TestKvStateMachine.java
@@ -1,0 +1,68 @@
+package com.song.yama.example.raft.support;
+
+import com.alibaba.fastjson.JSONObject;
+import com.alibaba.fastjson.TypeReference;
+import com.google.protobuf.ByteString;
+import com.song.yama.raft.Raft;
+import com.song.yama.raft.protobuf.RaftProtoBuf.Entry;
+import com.song.yama.raft.protobuf.RaftProtoBuf.EntryType;
+import com.song.yama.raft.protobuf.RaftProtoBuf.Message;
+import com.song.yama.raft.protobuf.RaftProtoBuf.MessageType;
+import com.song.yama.raft.protobuf.RaftProtoBuf.Snapshot;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * In-memory KV state machine for Raft fault tests (no Spring).
+ */
+public class TestKvStateMachine {
+
+    private ConcurrentMap<String, String> kvStorage = new ConcurrentHashMap<>();
+
+    public void propose(Raft raft, String key, String value) {
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("key", key);
+        jsonObject.put("value", value);
+        Message message = Message.newBuilder()
+            .setType(MessageType.MsgProp)
+            .setFrom(raft.getId())
+            .addEntries(Entry.newBuilder()
+                .setData(ByteString.copyFrom(jsonObject.toJSONString().getBytes()))
+                .build())
+            .build();
+        raft.step(message);
+    }
+
+    public void applyEntry(Entry entry) {
+        if (entry.getType() != EntryType.EntryNormal || entry.getData() == null || entry.getData().isEmpty()) {
+            return;
+        }
+        processCommits(entry.getData().toStringUtf8());
+    }
+
+    public void processCommits(String commit) {
+        JSONObject kv = JSONObject.parseObject(commit);
+        kvStorage.put(kv.getString("key"), kv.getString("value"));
+    }
+
+    public String lookup(String key) {
+        return kvStorage.get(key);
+    }
+
+    public byte[] getSnapshot() {
+        return JSONObject.toJSONString(kvStorage).getBytes();
+    }
+
+    public void loadSnapshot(Snapshot snapshot) {
+        if (snapshot == null) {
+            return;
+        }
+        kvStorage = JSONObject.parseObject(snapshot.getData().toByteArray(),
+            new TypeReference<ConcurrentMap<String, String>>() {
+            }.getType());
+    }
+
+    public int size() {
+        return kvStorage.size();
+    }
+}

--- a/yama-raft/src/test/java/com/song/yama/raft/wal/RocksDBCommitLogRecoveryTest.kt
+++ b/yama-raft/src/test/java/com/song/yama/raft/wal/RocksDBCommitLogRecoveryTest.kt
@@ -1,0 +1,125 @@
+package com.song.yama.raft.wal
+
+import com.song.yama.raft.protobuf.RaftProtoBuf.Entry
+import com.song.yama.raft.protobuf.RaftProtoBuf.EntryType
+import com.song.yama.raft.protobuf.RaftProtoBuf.HardState
+import com.song.yama.raft.protobuf.RaftProtoBuf.Snapshot
+import com.song.yama.raft.protobuf.RaftProtoBuf.SnapshotMetadata
+import com.song.yama.raft.protobuf.WALRecord
+import com.song.yama.raft.utils.ProtoBufUtils.buildEntry
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import java.io.File
+import java.nio.file.Files
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class RocksDBCommitLogRecoveryTest {
+
+    private lateinit var walDir: File
+    private lateinit var commitLog: RocksDBCommitLog
+
+    @Before
+    fun setUp() {
+        walDir = Files.createTempDirectory("yama-wal-test").toFile()
+        commitLog = RocksDBCommitLog(walDir.absolutePath)
+    }
+
+    @After
+    fun tearDown() {
+        try {
+            commitLog.close()
+        } catch (ignored: Exception) {
+        }
+        walDir.deleteRecursively()
+    }
+
+    @Test
+    fun readAllOnEmptyWal() {
+        val result = commitLog.readAll()
+        assertTrue(result.isSuccess)
+        val record = result.data!!
+        val ents = record.ents!!
+        assertTrue(ents.isEmpty())
+    }
+
+    @Test
+    fun walOnlyRecoveryPreservesEntriesAcrossTerms() {
+        val hardState = HardState.newBuilder().setTerm(2).setVote(1).setCommit(3).build()
+        val entries = listOf(
+            buildEntry("{\"key\":\"a\",\"value\":\"1\"}".toByteArray()).toBuilder().setIndex(1).setTerm(1).build(),
+            buildEntry("{\"key\":\"b\",\"value\":\"2\"}".toByteArray()).toBuilder().setIndex(2).setTerm(1).build(),
+            buildEntry("{\"key\":\"c\",\"value\":\"3\"}".toByteArray()).toBuilder().setIndex(3).setTerm(2).build()
+        )
+        assertTrue(commitLog.save(hardState, entries).isSuccess)
+
+        commitLog.close()
+        val reopened = RocksDBCommitLog(walDir.absolutePath)
+        val result = reopened.readAll()
+        reopened.close()
+
+        assertTrue(result.isSuccess)
+        val record = result.data!!
+        val ents = record.ents!!
+        assertEquals(3, ents.size)
+        assertEquals(3, record.hardState!!.commit)
+        assertEquals(1, ents[0].index)
+        assertEquals(1, ents[1].term)
+        assertEquals(3, ents[2].index)
+        assertEquals(2, ents[2].term)
+        assertEquals("{\"key\":\"c\",\"value\":\"3\"}", ents[2].data.toStringUtf8())
+    }
+
+    @Test
+    fun snapshotPlusWalRecoveryReadsPostSnapshotEntries() {
+        val snapshot = Snapshot.newBuilder()
+            .setMetadata(SnapshotMetadata.newBuilder().setIndex(5).setTerm(2).build())
+            .setData(com.google.protobuf.ByteString.copyFrom("{\"k\":\"v\"}".toByteArray()))
+            .build()
+        val snapRecord = WALRecord.Snapshot.newBuilder().setIndex(5).setTerm(2).build()
+        assertTrue(commitLog.saveSnap(snapRecord).isSuccess)
+
+        val postSnapshot = listOf(
+            Entry.newBuilder()
+                .setType(EntryType.EntryNormal)
+                .setIndex(6)
+                .setTerm(3)
+                .setData(com.google.protobuf.ByteString.copyFrom("after-snap".toByteArray()))
+                .build()
+        )
+        val hardState = HardState.newBuilder().setTerm(3).setVote(1).setCommit(6).build()
+        assertTrue(commitLog.save(hardState, postSnapshot).isSuccess)
+
+        commitLog.close()
+        val reopened = RocksDBCommitLog(walDir.absolutePath)
+        val result = reopened.readAll(snapshot)
+        reopened.close()
+
+        assertTrue(result.isSuccess)
+        val record = result.data!!
+        val ents = record.ents!!
+        assertEquals(1, ents.size)
+        assertEquals(6, ents[0].index)
+        assertEquals(3, ents[0].term)
+        assertEquals("after-snap", ents[0].data.toStringUtf8())
+    }
+
+    @Test
+    fun entryKeyIsIndexOnlyNotTermBound() {
+        val e1 = buildEntry("x".toByteArray()).toBuilder().setIndex(1).setTerm(1).build()
+        val e2 = buildEntry("y".toByteArray()).toBuilder().setIndex(2).setTerm(5).build()
+        assertTrue(commitLog.save(HardState.newBuilder().setTerm(5).setCommit(2).build(), listOf(e1, e2)).isSuccess)
+
+        commitLog.close()
+        val reopened = RocksDBCommitLog(walDir.absolutePath)
+        val result = reopened.readAll()
+        reopened.close()
+
+        val record = result.data!!
+        val ents = record.ents!!
+        assertEquals(2, ents.size)
+        assertEquals(5, ents[1].term)
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

为 `yama-example-raft` 分布式 KV 示例补充全面的故障测试体系，修复测试过程中发现的恢复相关问题，并沉淀故障测试文档。

## 测试覆盖

### 新增测试（26 个）

| 测试类 | 场景数 | 说明 |
|--------|--------|------|
| `KvRaftFaultTest` | 8 | 三节点复制、非对称丢包、分区恢复、Leader 切换、少数派、旧 Leader 重入、大量写入、Follower 过期读（内存模拟） |
| `RaftKvFaultIntegrationTest` | 7 | **真实 Spring Boot 三节点**：HTTP 复制、Leader 宕机、Follower 追赶、网络分区、多数派选主 |
| `KVStateMachineTest` | 5 | 状态机 JSON 编解码、快照往返 |
| `RaftKvRecoveryIntegrationTest` | 2 | 仅 WAL 重启恢复、快照后重启恢复 |
| `RocksDBCommitLogRecoveryTest` | 4 | WAL 空读、跨 term 条目、快照+增量、index-only key |

### 测试基础设施

- `KvRaftCluster` — 内存多节点 Raft+KV 模拟器（快速、确定性）
- `RaftKvClusterHarness` — 真实三节点 Spring Boot 集群管理
- `FaultInjectingHttpMessagingService` — HTTP 层网络故障注入（`integration-fault-test` profile）

## Bug 修复

1. **无快照启动时 WAL 未回放到状态机**：新增 `replayEntriesToStateMachine()`
2. **`publishSnapshot` 使用错误快照源**：改为 `loadSnapshot(snapshotToSave)`
3. **多快照文件加载顺序不确定**：按 index 取最新快照
4. **节点关闭时 RocksDB SIGSEGV**：优雅关闭线程池后再关闭 WAL
5. **测试数据目录不可配置**：新增 `com.song.yama.raft.data-dir`

## 文档

- `docs/kv-raft-fault-testing.md`：故障场景说明、内存/集成测试运行方式、已知限制

## 验证

```
mvn test -pl yama-example-raft
# Tests run: 23, Failures: 0
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1b23-5455-7252-ba59-301b89f0e6fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1b23-5455-7252-ba59-301b89f0e6fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

