### PR TITLE
feat: 支持 ReadIndex 线性一致读

### DIFF
--- a/yama-example-raft/src/main/java/com/song/yama/example/raft/controller/ApiController.java
+++ b/yama-example-raft/src/main/java/com/song/yama/example/raft/controller/ApiController.java
@@ -17,8 +17,11 @@
 package com.song.yama.example.raft.controller;
 
 import com.song.yama.example.raft.core.StateMachine;
+import com.song.yama.raft.exception.RaftException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -35,8 +38,14 @@ public class ApiController {
 
     @GetMapping("/get")
     public @ResponseBody
-    String get(String key) {
-        return stateMachine.lookup(key);
+    ResponseEntity<String> get(String key) {
+        try {
+            return ResponseEntity.ok(stateMachine.lookup(key));
+        } catch (RaftException e) {
+            log.warn("Linearizable read failed for key {}: {}", key, e.getMessage());
+            return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
+                .body("read unavailable: " + e.getMessage());
+        }
     }
 
     @GetMapping("/put")

--- a/yama-example-raft/src/main/java/com/song/yama/example/raft/core/RaftNode.java
+++ b/yama-example-raft/src/main/java/com/song/yama/example/raft/core/RaftNode.java
@@ -28,6 +28,7 @@ import com.song.yama.raft.Node;
 import com.song.yama.raft.Peer;
 import com.song.yama.raft.RaftConfiguration;
 import com.song.yama.raft.RaftStorage;
+import com.song.yama.raft.ReadState;
 import com.song.yama.raft.Ready;
 import com.song.yama.raft.exception.RaftException;
 import com.song.yama.raft.protobuf.RaftProtoBuf.ConfChange;
@@ -44,15 +45,24 @@ import com.song.yama.raft.wal.RaftStateRecord;
 import com.song.yama.raft.wal.RocksDBCommitLog;
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import lombok.Getter;
@@ -71,6 +81,8 @@ public class RaftNode {
     private static final long DEFAULT_SNAPSHOT_COUNT = 10;
 
     private static final long SNAPSHOT_CATCHUP_ENTRIES_N = 10;
+
+    private static final long READ_INDEX_TIMEOUT_MS = 5000L;
 
     /**
      * client ID for raft session
@@ -108,7 +120,17 @@ public class RaftNode {
 
     private long snapshotIndex;
 
-    private long appliedIndex;
+    private volatile long appliedIndex;
+
+    private final Object appliedIndexLock = new Object();
+
+    private final Object raftLock = new Object();
+
+    private final BlockingQueue<Message> inboundMessages = new LinkedBlockingQueue<>();
+
+    private final BlockingQueue<byte[]> pendingReadIndexRequests = new LinkedBlockingQueue<>();
+
+    private final ConcurrentMap<String, CompletableFuture<Long>> pendingReadIndexes = new ConcurrentHashMap<>();
 
     private long snapCount = DEFAULT_SNAPSHOT_COUNT;
 
@@ -226,15 +248,94 @@ public class RaftNode {
         log.info("update appliedIndex:{}.", this.appliedIndex);
 
         this.scheduledExecutorService
-            .scheduleAtFixedRate(this.node::tick, 100, 100,
-                TimeUnit.MILLISECONDS);
+            .scheduleAtFixedRate(() -> {
+                synchronized (this.raftLock) {
+                    this.node.tick();
+                }
+                this.inboundMessages.offer(Message.getDefaultInstance());
+            }, 100, 100, TimeUnit.MILLISECONDS);
 
         this.running = true;
         this.taskThreadPool.submit(new ReadyProcessor(this));
     }
 
     public void processMessage(Message message) {
-        this.node.step(message);
+        this.inboundMessages.offer(message);
+    }
+
+    /**
+     * Perform a linearizable read by issuing readIndex and waiting until the state machine
+     * has applied entries up to the confirmed read index.
+     */
+    public <T> T linearizableRead(Supplier<T> readAction) {
+        byte[] requestCtx = UUID.randomUUID().toString().getBytes(StandardCharsets.UTF_8);
+        String requestKey = new String(requestCtx, StandardCharsets.UTF_8);
+        CompletableFuture<Long> readIndexFuture = new CompletableFuture<>();
+        pendingReadIndexes.put(requestKey, readIndexFuture);
+        this.pendingReadIndexRequests.offer(requestCtx);
+        this.inboundMessages.offer(Message.getDefaultInstance());
+        try {
+            long readIndex = readIndexFuture.get(READ_INDEX_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+            waitUntilApplied(readIndex);
+            return readAction.get();
+        } catch (TimeoutException e) {
+            throw new RaftException("ReadIndex timed out waiting for quorum confirmation", e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RaftException("ReadIndex interrupted", e);
+        } catch (java.util.concurrent.ExecutionException e) {
+            throw new RaftException("ReadIndex failed", e.getCause());
+        } finally {
+            pendingReadIndexes.remove(requestKey);
+        }
+    }
+
+    private void drainRaftWork() {
+        Message message;
+        while ((message = this.inboundMessages.poll()) != null) {
+            if (message.getSerializedSize() > 0) {
+                this.node.step(message);
+            }
+        }
+        byte[] requestCtx;
+        while ((requestCtx = this.pendingReadIndexRequests.poll()) != null) {
+            this.node.readIndex(requestCtx);
+        }
+    }
+
+    private void waitUntilApplied(long readIndex) throws InterruptedException, TimeoutException {
+        long deadlineNanos = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(READ_INDEX_TIMEOUT_MS);
+        synchronized (this.appliedIndexLock) {
+            while (this.appliedIndex < readIndex) {
+                long remainingNanos = deadlineNanos - System.nanoTime();
+                if (remainingNanos <= 0) {
+                    throw new TimeoutException(
+                        "Timed out waiting for appliedIndex >= " + readIndex + ", current=" + this.appliedIndex);
+                }
+                long waitMillis = remainingNanos / 1_000_000L;
+                int waitNanos = (int) (remainingNanos % 1_000_000L);
+                this.appliedIndexLock.wait(waitMillis, waitNanos);
+            }
+        }
+    }
+
+    private void notifyAppliedIndexUpdated() {
+        synchronized (this.appliedIndexLock) {
+            this.appliedIndexLock.notifyAll();
+        }
+    }
+
+    private void processReadStates(List<ReadState> readStates) {
+        if (CollectionUtils.isEmpty(readStates)) {
+            return;
+        }
+        for (ReadState readState : readStates) {
+            String requestKey = new String(readState.getRequestCtx(), StandardCharsets.UTF_8);
+            CompletableFuture<Long> future = pendingReadIndexes.get(requestKey);
+            if (future != null) {
+                future.complete(readState.getIndex());
+            }
+        }
     }
 
     private void publishEntries(List<Entry> entries) {
@@ -278,6 +379,7 @@ public class RaftNode {
             // after commit, update appliedIndex
             this.appliedIndex = entry.getIndex();
             log.info("Update appliedIndex:{}.", this.appliedIndex);
+            notifyAppliedIndexUpdated();
         });
     }
 
@@ -289,6 +391,7 @@ public class RaftNode {
                 }
             }
             this.appliedIndex = entry.getIndex();
+            notifyAppliedIndexUpdated();
         });
     }
 
@@ -307,6 +410,7 @@ public class RaftNode {
         this.snapshotIndex = snapshotToSave.getMetadata().getIndex();
         this.appliedIndex = snapshotToSave.getMetadata().getIndex();
         log.info("Update appliedIndex:{}.", this.appliedIndex);
+        notifyAppliedIndexUpdated();
         log.info("publishing snapshot at index {}", this.snapshotIndex);
     }
 
@@ -396,20 +500,34 @@ public class RaftNode {
         public void run() {
             while (raftNode.running) {
                 try {
-                    Ready ready = raftNode.node.pullReady();
-                    raftNode.commitLog.save(ready.getHardState(), ready.getCommittedEntries());
-                    if (!Utils.INSTANCE.isEmptySnap(ready.getSnapshot())) {
-                        saveSnap(Objects.requireNonNull(ready.getSnapshot()));
-                        raftNode.raftStorage.applySnapshot(ready.getSnapshot());
-                        publishSnapshot(ready.getSnapshot());
+                    Ready ready;
+                    synchronized (raftNode.raftLock) {
+                        raftNode.drainRaftWork();
+                        ready = raftNode.node.tryPullReady();
+                        if (ready == null) {
+                            continue;
+                        }
+                        raftNode.commitLog.save(ready.getHardState(), ready.getCommittedEntries());
+                        if (!Utils.INSTANCE.isEmptySnap(ready.getSnapshot())) {
+                            saveSnap(Objects.requireNonNull(ready.getSnapshot()));
+                            raftNode.raftStorage.applySnapshot(ready.getSnapshot());
+                            publishSnapshot(ready.getSnapshot());
+                        }
+                        raftNode.raftStorage.append(ready.getEntries());
+                        raftNode.messagingService.send(ready.getMessages());
+                        processReadStates(ready.getReadStates());
+                        publishEntries(entriesToApply(ready.getCommittedEntries()));
+                        maybeTriggerSnapshot();
+                        raftNode.node.advance(ready);
                     }
-                    raftNode.raftStorage.append(ready.getEntries());
-                    raftNode.messagingService.send(ready.getMessages());
-                    publishEntries(entriesToApply(ready.getCommittedEntries()));
-                    maybeTriggerSnapshot();
-                    raftNode.node.advance(ready);
                 } catch (Exception e) {
                     log.error("Process ready failed", e);
+                }
+                try {
+                    Thread.sleep(1);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    break;
                 }
             }
         }

--- a/yama-example-raft/src/main/java/com/song/yama/example/raft/core/kVStateMachine.java
+++ b/yama-example-raft/src/main/java/com/song/yama/example/raft/core/kVStateMachine.java
@@ -45,7 +45,7 @@ public class kVStateMachine implements StateMachine {
 
     @Override
     public String lookup(String key) {
-        return this.kvStorage.get(key);
+        return this.raftNode.linearizableRead(() -> this.kvStorage.get(key));
     }
 
     @Override

--- a/yama-example-raft/src/test/java/com/song/yama/example/raft/RaftKvFaultIntegrationTest.java
+++ b/yama-example-raft/src/test/java/com/song/yama/example/raft/RaftKvFaultIntegrationTest.java
@@ -2,13 +2,14 @@ package com.song.yama.example.raft;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
 
 import com.song.yama.example.raft.support.FaultInjectionRegistry;
 import com.song.yama.example.raft.support.RaftKvClusterHarness;
 import com.song.yama.example.raft.support.RaftKvHttpClient;
 import org.junit.After;
 import org.junit.Test;
+import org.springframework.web.client.HttpServerErrorException;
 
 /**
  * Integration fault tests using real Spring Boot nodes and HTTP APIs.
@@ -99,8 +100,8 @@ public class RaftKvFaultIntegrationTest {
         Thread.sleep(1500);
 
         assertEquals("newval", client.get(cluster.leaderPort(), "newkey"));
-        assertNull(client.get(cluster.node(isolatedId).getPort(), "newkey"));
-        assertEquals("yes", client.get(cluster.node(isolatedId).getPort(), "synced"));
+        assertReadUnavailable(cluster.node(isolatedId).getPort(), "newkey");
+        assertReadUnavailable(cluster.node(isolatedId).getPort(), "synced");
 
         FaultInjectionRegistry.recover();
         Thread.sleep(2000);
@@ -163,5 +164,14 @@ public class RaftKvFaultIntegrationTest {
             }
         }
         return count;
+    }
+
+    private void assertReadUnavailable(int port, String key) {
+        try {
+            client.get(port, key);
+            fail("Expected linearizable read to fail on isolated node for key: " + key);
+        } catch (HttpServerErrorException e) {
+            assertEquals(503, e.getRawStatusCode());
+        }
     }
 }

--- a/yama-example-raft/src/test/java/com/song/yama/example/raft/RaftKvFaultIntegrationTest.java
+++ b/yama-example-raft/src/test/java/com/song/yama/example/raft/RaftKvFaultIntegrationTest.java
@@ -156,6 +156,99 @@ public class RaftKvFaultIntegrationTest {
         }
     }
 
+    @Test
+    public void readIndexOnFollowerMatchesLeader() throws Exception {
+        cluster = RaftKvClusterHarness.startThreeNodeCluster();
+        int leaderId = cluster.leaderId();
+        cluster.putOnLeader(client, "color", "blue");
+
+        for (int id = 1; id <= 3; id++) {
+            if (id != leaderId) {
+                assertEquals("blue", client.get(cluster.node(id).getPort(), "color"));
+            }
+        }
+    }
+
+    @Test
+    public void readIndexAfterLeaderFailover() throws Exception {
+        cluster = RaftKvClusterHarness.startThreeNodeCluster();
+        int oldLeaderId = cluster.leaderId();
+        cluster.putOnLeader(client, "persist", "value");
+
+        cluster.stopNode(oldLeaderId);
+        Thread.sleep(3000);
+        cluster.waitForLeader(80);
+
+        int newLeaderPort = cluster.leaderPort();
+        assertEquals("value", client.get(newLeaderPort, "persist"));
+
+        for (int id = 1; id <= 3; id++) {
+            if (id != oldLeaderId) {
+                assertEquals("value", client.get(cluster.node(id).getPort(), "persist"));
+            }
+        }
+    }
+
+    @Test
+    public void isolatedOldLeaderReturns503OnRead() throws Exception {
+        cluster = RaftKvClusterHarness.startThreeNodeCluster();
+        int oldLeaderId = cluster.leaderId();
+        cluster.putOnLeader(client, "seed", "data");
+
+        FaultInjectionRegistry.isolate(oldLeaderId);
+        Thread.sleep(3000);
+        cluster.waitForLeader(80);
+
+        assertReadUnavailable(cluster.node(oldLeaderId).getPort(), "seed");
+        assertReadUnavailable(cluster.node(oldLeaderId).getPort(), "missing");
+    }
+
+    @Test
+    public void partitionHealRestoresLinearizableRead() throws Exception {
+        cluster = RaftKvClusterHarness.startThreeNodeCluster();
+        int leaderId = cluster.leaderId();
+        cluster.putOnLeader(client, "synced", "yes");
+
+        int isolatedId = 1;
+        while (isolatedId == leaderId) {
+            isolatedId++;
+        }
+
+        FaultInjectionRegistry.isolate(isolatedId);
+        client.put(cluster.leaderPort(), "heal-key", "heal-val");
+        Thread.sleep(1500);
+
+        client.waitForReadUnavailable(cluster.node(isolatedId).getPort(), "heal-key", 30);
+
+        FaultInjectionRegistry.recover();
+        Thread.sleep(2000);
+        client.waitFor(cluster.node(isolatedId).getPort(), "heal-key", "heal-val", 80);
+        assertEquals("yes", client.get(cluster.node(isolatedId).getPort(), "synced"));
+    }
+
+    @Test
+    public void isolatedFollowerCannotReadWhileLeaderCan() throws Exception {
+        cluster = RaftKvClusterHarness.startThreeNodeCluster();
+        int leaderId = cluster.leaderId();
+        cluster.putOnLeader(client, "base", "v0");
+
+        int followerId = 1;
+        while (followerId == leaderId) {
+            followerId++;
+        }
+
+        FaultInjectionRegistry.isolate(followerId);
+        client.put(cluster.leaderPort(), "blocked", "yes");
+        Thread.sleep(1500);
+
+        client.waitFor(cluster.leaderPort(), "blocked", "yes", 80);
+        client.waitForReadUnavailable(cluster.node(followerId).getPort(), "blocked", 30);
+
+        FaultInjectionRegistry.recover();
+        Thread.sleep(2000);
+        client.waitFor(cluster.node(followerId).getPort(), "blocked", "yes", 80);
+    }
+
     private int countLeaders() {
         int count = 0;
         for (int id = 1; id <= 3; id++) {

--- a/yama-example-raft/src/test/java/com/song/yama/example/raft/ReadIndexKvRaftFaultTest.java
+++ b/yama-example-raft/src/test/java/com/song/yama/example/raft/ReadIndexKvRaftFaultTest.java
@@ -1,0 +1,123 @@
+package com.song.yama.example.raft;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import com.song.yama.example.raft.support.KvRaftCluster;
+import com.song.yama.example.raft.support.ReadIndexKvTestHelper;
+import org.junit.Test;
+
+/**
+ * Fault tests for ReadIndex linearizable reads using the in-memory KV Raft harness.
+ */
+public class ReadIndexKvRaftFaultTest {
+
+    @Test
+    public void linearizableReadReturnsCommittedValueOnAllNodes() {
+        KvRaftCluster cluster = KvRaftCluster.newCluster(3);
+        cluster.electLeader(1);
+        cluster.put(1, "name", "alice");
+        cluster.sync();
+
+        for (long nodeId = 1; nodeId <= 3; nodeId++) {
+            assertEquals("alice", ReadIndexKvTestHelper.linearizableLookup(cluster, nodeId, "name"));
+        }
+    }
+
+    @Test
+    public void directLookupMayBeStaleButReadIndexIsLinearizable() {
+        KvRaftCluster cluster = KvRaftCluster.newCluster(3);
+        cluster.electLeader(1);
+        cluster.put(1, "synced", "yes");
+        cluster.sync();
+
+        cluster.isolate(2);
+        cluster.put(1, "newkey", "newval");
+        cluster.sync();
+
+        assertEquals("newval", cluster.node(1).getKv().lookup("newkey"));
+        assertEquals("newval", cluster.node(3).getKv().lookup("newkey"));
+        assertNull(cluster.node(2).getKv().lookup("newkey"));
+
+        assertEquals("newval", ReadIndexKvTestHelper.linearizableLookup(cluster, 1, "newkey"));
+        assertEquals("newval", ReadIndexKvTestHelper.linearizableLookup(cluster, 3, "newkey"));
+        ReadIndexKvTestHelper.assertLinearizableReadUnavailable(cluster, 2, "newkey");
+        ReadIndexKvTestHelper.assertLinearizableReadUnavailable(cluster, 2, "synced");
+    }
+
+    @Test
+    public void partitionHealRestoresLinearizableRead() {
+        KvRaftCluster cluster = KvRaftCluster.newCluster(3);
+        cluster.electLeader(1);
+        cluster.put(1, "seed", "v0");
+        cluster.sync();
+
+        cluster.isolate(2);
+        cluster.put(1, "after", "partition");
+        cluster.sync();
+
+        ReadIndexKvTestHelper.assertLinearizableReadUnavailable(cluster, 2, "after");
+
+        cluster.recover();
+        cluster.heartbeat(1);
+        cluster.sync();
+
+        assertEquals("partition", ReadIndexKvTestHelper.linearizableLookup(cluster, 2, "after"));
+        assertEquals("v0", ReadIndexKvTestHelper.linearizableLookup(cluster, 2, "seed"));
+    }
+
+    @Test
+    public void leaderFailoverPreservesLinearizableRead() {
+        KvRaftCluster cluster = KvRaftCluster.newCluster(3);
+        cluster.electLeader(1);
+        cluster.put(1, "k1", "v1");
+        cluster.sync();
+
+        cluster.isolate(1);
+        cluster.electLeader(2);
+        cluster.put(2, "k2", "v2");
+        cluster.sync();
+
+        assertEquals("v1", ReadIndexKvTestHelper.linearizableLookup(cluster, 2, "k1"));
+        assertEquals("v2", ReadIndexKvTestHelper.linearizableLookup(cluster, 3, "k2"));
+        ReadIndexKvTestHelper.assertLinearizableReadUnavailable(cluster, 1, "k2");
+    }
+
+    @Test
+    public void asymmetricDropBlocksLinearizableReadOnFollower() {
+        KvRaftCluster cluster = KvRaftCluster.newCluster(3);
+        cluster.electLeader(1);
+        cluster.put(1, "seed", "v0");
+        cluster.sync();
+
+        cluster.drop(2, 1, 1.0f);
+        cluster.drop(1, 2, 1.0f);
+        cluster.put(1, "blocked", "yes");
+        cluster.sync();
+
+        assertEquals("yes", ReadIndexKvTestHelper.linearizableLookup(cluster, 1, "blocked"));
+        ReadIndexKvTestHelper.assertLinearizableReadUnavailable(cluster, 2, "blocked");
+    }
+
+    @Test
+    public void oldLeaderRejoinsLinearizableReadConverges() {
+        KvRaftCluster cluster = KvRaftCluster.newCluster(3);
+        cluster.electLeader(1);
+        cluster.put(1, "a", "1");
+        cluster.sync();
+
+        cluster.isolate(1);
+        cluster.electLeader(2);
+        cluster.put(2, "b", "2");
+        cluster.sync();
+
+        cluster.recover();
+        cluster.heartbeat(2);
+        cluster.sync();
+
+        for (long nodeId = 1; nodeId <= 3; nodeId++) {
+            assertEquals("1", ReadIndexKvTestHelper.linearizableLookup(cluster, nodeId, "a"));
+            assertEquals("2", ReadIndexKvTestHelper.linearizableLookup(cluster, nodeId, "b"));
+        }
+    }
+}

--- a/yama-example-raft/src/test/java/com/song/yama/example/raft/support/KvRaftTestNode.java
+++ b/yama-example-raft/src/test/java/com/song/yama/example/raft/support/KvRaftTestNode.java
@@ -1,12 +1,16 @@
 package com.song.yama.example.raft.support;
 
 import com.google.common.collect.Lists;
+import com.google.protobuf.ByteString;
 import com.song.yama.raft.MemoryRaftStorage;
 import com.song.yama.raft.Raft;
 import com.song.yama.raft.RaftConfiguration;
+import com.song.yama.raft.ReadState;
 import com.song.yama.raft.StateType;
 import com.song.yama.raft.protobuf.RaftProtoBuf.Entry;
 import com.song.yama.raft.protobuf.RaftProtoBuf.Message;
+import com.song.yama.raft.protobuf.RaftProtoBuf.MessageType;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -19,6 +23,7 @@ public class KvRaftTestNode {
     private final Raft raft;
     private final MemoryRaftStorage storage;
     private final TestKvStateMachine kv;
+    private long appliedIndex;
 
     public KvRaftTestNode(long id, List<Long> peerIds) {
         this.id = id;
@@ -51,6 +56,10 @@ public class KvRaftTestNode {
         return kv;
     }
 
+    public long getAppliedIndex() {
+        return appliedIndex;
+    }
+
     public boolean isLeader() {
         return raft.getState() == StateType.LEADER;
     }
@@ -71,8 +80,33 @@ public class KvRaftTestNode {
         List<Entry> entries = raft.getRaftLog().nextEnts();
         for (Entry entry : entries) {
             kv.applyEntry(entry);
+            appliedIndex = entry.getIndex();
         }
         raft.getRaftLog().appliedTo(raft.getRaftLog().getCommitted());
+    }
+
+    public void requestReadIndex(byte[] requestCtx) {
+        Message message = Message.newBuilder()
+            .setType(MessageType.MsgReadIndex)
+            .setFrom(id)
+            .addEntries(Entry.newBuilder()
+                .setData(ByteString.copyFrom(requestCtx))
+                .build())
+            .build();
+        raft.step(message);
+    }
+
+    public ReadState pollReadState(byte[] requestCtx) {
+        String requestKey = new String(requestCtx, StandardCharsets.UTF_8);
+        List<ReadState> readStates = raft.getReadStates();
+        for (int i = 0; i < readStates.size(); i++) {
+            ReadState readState = readStates.get(i);
+            if (requestKey.equals(new String(readState.getRequestCtx(), StandardCharsets.UTF_8))) {
+                readStates.remove(i);
+                return readState;
+            }
+        }
+        return null;
     }
 
     public void propose(String key, String value) {

--- a/yama-example-raft/src/test/java/com/song/yama/example/raft/support/RaftKvHttpClient.java
+++ b/yama-example-raft/src/test/java/com/song/yama/example/raft/support/RaftKvHttpClient.java
@@ -18,6 +18,27 @@ public final class RaftKvHttpClient {
         return restTemplate.getForObject(url(port, "/get?key=" + key), String.class);
     }
 
+    public boolean isReadUnavailable(int port, String key) {
+        try {
+            get(port, key);
+            return false;
+        } catch (org.springframework.web.client.HttpServerErrorException e) {
+            return e.getRawStatusCode() == 503;
+        }
+    }
+
+    public void waitForReadUnavailable(int port, String key, int attempts) throws InterruptedException {
+        for (int i = 0; i < attempts; i++) {
+            if (isReadUnavailable(port, key)) {
+                return;
+            }
+            Thread.sleep(100);
+        }
+        if (!isReadUnavailable(port, key)) {
+            throw new AssertionError("Expected read to be unavailable on port " + port + " for key " + key);
+        }
+    }
+
     public void waitFor(int port, String key, String expected, int attempts) throws InterruptedException {
         for (int i = 0; i < attempts; i++) {
             String actual = get(port, key);

--- a/yama-example-raft/src/test/java/com/song/yama/example/raft/support/ReadIndexKvTestHelper.java
+++ b/yama-example-raft/src/test/java/com/song/yama/example/raft/support/ReadIndexKvTestHelper.java
@@ -1,0 +1,65 @@
+package com.song.yama.example.raft.support;
+
+import com.song.yama.raft.ReadState;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+/**
+ * Helper for exercising ReadIndex linearizable reads in in-memory KV Raft tests.
+ */
+public final class ReadIndexKvTestHelper {
+
+    private static final int MAX_ROUNDS = 200;
+
+    private ReadIndexKvTestHelper() {
+    }
+
+    public static String linearizableLookup(KvRaftCluster cluster, long nodeId, String key) {
+        KvRaftTestNode node = cluster.node(nodeId);
+        byte[] requestCtx = UUID.randomUUID().toString().getBytes(StandardCharsets.UTF_8);
+        node.requestReadIndex(requestCtx);
+
+        long readIndex = waitForReadIndex(cluster, node, requestCtx);
+        waitUntilApplied(cluster, node, readIndex);
+        return node.getKv().lookup(key);
+    }
+
+    public static void assertLinearizableReadUnavailable(KvRaftCluster cluster, long nodeId, String key) {
+        try {
+            linearizableLookup(cluster, nodeId, key);
+            throw new AssertionError("Expected ReadIndex to fail on node " + nodeId + " for key " + key);
+        } catch (ReadIndexUnavailableException expected) {
+            // expected
+        }
+    }
+
+    private static long waitForReadIndex(KvRaftCluster cluster, KvRaftTestNode node, byte[] requestCtx) {
+        for (int round = 0; round < MAX_ROUNDS; round++) {
+            cluster.sync();
+            ReadState readState = node.pollReadState(requestCtx);
+            if (readState != null) {
+                return readState.getIndex();
+            }
+        }
+        throw new ReadIndexUnavailableException(
+            "ReadIndex timed out on node " + node.getId() + " after " + MAX_ROUNDS + " rounds");
+    }
+
+    private static void waitUntilApplied(KvRaftCluster cluster, KvRaftTestNode node, long readIndex) {
+        for (int round = 0; round < MAX_ROUNDS; round++) {
+            if (node.getAppliedIndex() >= readIndex) {
+                return;
+            }
+            cluster.sync();
+        }
+        throw new ReadIndexUnavailableException(String.format(
+            "Applied index did not reach read index on node %d (applied=%d, readIndex=%d)",
+            node.getId(), node.getAppliedIndex(), readIndex));
+    }
+
+    public static final class ReadIndexUnavailableException extends RuntimeException {
+        public ReadIndexUnavailableException(String message) {
+            super(message);
+        }
+    }
+}

--- a/yama-raft/src/main/java/com/song/yama/raft/DefaultNode.kt
+++ b/yama-raft/src/main/java/com/song/yama/raft/DefaultNode.kt
@@ -137,12 +137,21 @@ class DefaultNode : Node {
     @Throws(InterruptedException::class)
     override fun pullReady(): Ready {
         while (true) {
-            val ready = Ready(raft!!, this.preSoftState!!, this.preHardState!!)
-            if (ready.containsUpdates()) {
+            val ready = tryPullReady()
+            if (ready != null) {
                 return ready
             }
             Thread.sleep(1)
             log.info("Sleep!!")
+        }
+    }
+
+    override fun tryPullReady(): Ready? {
+        val ready = Ready(raft!!, this.preSoftState!!, this.preHardState!!)
+        return if (ready.containsUpdates()) {
+            ready
+        } else {
+            null
         }
     }
 
@@ -250,6 +259,7 @@ class DefaultNode : Node {
     override fun readIndex(rctx: ByteArray) {
         this.raft!!.step(Message.newBuilder()
                 .setType(MessageType.MsgReadIndex)
+                .setFrom(this.raft!!.id)
                 .addEntries(Entry.newBuilder()
                         .setData(ByteString.copyFrom(rctx))
                         .build())

--- a/yama-raft/src/main/java/com/song/yama/raft/Node.kt
+++ b/yama-raft/src/main/java/com/song/yama/raft/Node.kt
@@ -77,6 +77,11 @@ interface Node {
     fun pullReady(): Ready
 
     /**
+     * Returns a Ready if there are pending updates, otherwise null.
+     */
+    fun tryPullReady(): Ready?
+
+    /**
      * Advance notifies the Node that the application has saved progress up to the last Ready. It prepares the node to
      * return the next available Ready.
      *

--- a/yama-raft/src/main/java/com/song/yama/raft/Ready.kt
+++ b/yama-raft/src/main/java/com/song/yama/raft/Ready.kt
@@ -125,8 +125,8 @@ class Ready(val raft: Raft, val preSoftSt: SoftState, val preHardSt: HardState) 
         }
 
         if (CollectionUtils.isNotEmpty(raft.readStates)) {
-            this.readStates = raft.readStates
-            this.readStates.clear()
+            this.readStates = ArrayList(raft.readStates)
+            raft.readStates.clear()
         }
 
         this.mustSync = mustSync(raft.hardState(), preHardSt, this.entries.size)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

为 KV 示例应用接入 Raft ReadIndex 线性一致读，修复底层 Raft 库中 ReadState 传递的两个关键 bug，并统一 Raft 事件处理到单线程循环以避免并发竞态。

## Changes

### yama-raft（底层修复）

- **`Ready.kt`**：`readStates` 改为拷贝后清空，修复原先直接 `clear()` 共享列表导致应用层永远收不到 ReadState 的问题
- **`DefaultNode.readIndex`**：补充 `from` 字段，确保 follower 发起的读请求能收到 leader 的 `MsgReadIndexResp`
- **`Node.tryPullReady()`**：新增非阻塞 Ready 轮询接口，供应用层事件循环使用

### yama-example-raft（应用层接入）

- **`RaftNode.linearizableRead()`**：发起 `readIndex` → 等待 quorum 确认 → 等待 `appliedIndex` 追上 → 执行本地读
- **单线程 Raft 事件循环**：所有 `step()` / `readIndex()` / `tick()` 通过队列串行处理，消除 HTTP 线程与 ReadyProcessor 并发访问 Raft 状态的竞态
- **`kVStateMachine.lookup()`**：`get` 请求改为走 `linearizableRead`
- **`ApiController`**：读失败时返回 HTTP 503（如网络分区下无法确认线性一致性）

### 故障测试（新增）

**内存级 `ReadIndexKvRaftFaultTest`（6 个用例）**
- 全节点线性一致读返回已提交值
- 直接读可能过期 vs ReadIndex 线性一致
- 分区恢复后线性读恢复
- Leader 切换后线性读保留数据
- 单向断连阻塞 follower 线性读
- 旧 Leader 重新加入后全节点线性读收敛

**HTTP 集成 `RaftKvFaultIntegrationTest`（新增 5 个用例）**
- Follower ReadIndex 与 Leader 一致
- Leader 故障切换后 ReadIndex 可读历史数据
- 被隔离的旧 Leader 读请求返回 503
- 分区恢复后线性读恢复
- 被隔离 Follower 不可读、Leader 可读、恢复后可读

## Behavior change

| 场景 | 之前 | 之后 |
|------|------|------|
| 正常读（leader/follower） | 直接读本地内存，可能过期 | 经 ReadIndex 确认后读，线性一致 |
| 网络分区中的 follower | 可能返回过期数据 | 返回 503，拒绝不确定的读 |

## Test plan

- [x] `mvn test -pl yama-raft,yama-example-raft` — 34 个测试全部通过
- [x] 集成测试 `networkPartitionMakesFollowerStaleUntilHeal` 已更新：隔离节点读请求预期返回 503
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1b50-53c4-74d4-a4c6-a31a84baad22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1b50-53c4-74d4-a4c6-a31a84baad22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

