### PR TITLE
test: 增加 JSON 故障测试

### DIFF
--- a/docs/kv-raft-fault-testing.md
+++ b/docs/kv-raft-fault-testing.md
@@ -29,6 +29,7 @@ Client ──GET /put,/get──► ApiController
 | WAL 持久化 | `yama-raft` | `RocksDBCommitLogRecoveryTest` | 空 WAL、跨 term 条目、快照+增量条目、index-only key |
 | KV 状态机 | `yama-example-raft` | `KVStateMachineTest` | JSON 编解码、快照往返、ConfChange 忽略 |
 | 多节点故障 | `yama-example-raft` | `KvRaftFaultTest` | 复制、分区、Leader 切换、少数派、日志收敛 |
+| **JSON 故障** | `yama-example-raft` | `JsonKvRaftFaultTest` | Unicode/转义/类 JSON 值在分区、Leader 切换下的一致性 |
 | **集成故障（HTTP）** | `yama-example-raft` | `RaftKvFaultIntegrationTest` | 真实三节点 Spring Boot、Leader 宕机、网络分区、Follower 追赶 |
 | 端到端重启 | `yama-example-raft` | `RaftKvRecoveryIntegrationTest` | 仅 WAL 重启、快照后重启 |
 | Raft 协议 | `yama-raft` | `RaftFaultInjectionTest` | 非对称丢包、少数派、旧 Leader 重入（库层） |
@@ -92,6 +93,8 @@ Leader → Follower 链路断开时，新写入只在 Leader 本地提交（若�
 | `networkPartitionMakesFollowerStaleUntilHeal` | 隔离 Follower，验证过期读，恢复后收敛 |
 | `isolatedOldLeaderMajorityReElects` | 隔离旧 Leader，多数派重新选主 |
 | `manyWritesConsistentAcrossThreeNodes` | 12 次 HTTP 写入三节点一致 |
+| `specialJsonValuesReplicateOverHttp` | HTTP 写入 Unicode/转义/类 JSON 值，三节点一致 |
+| `specialJsonValuesConvergeAfterPartition` | 分区期间写入特殊 JSON 值，恢复后收敛 |
 
 ```bash
 # 仅集成故障测试（约 1 分钟，每个用例独立 JVM）
@@ -148,7 +151,7 @@ com.song.yama.raft.servers=127.0.0.1:9001
 mvn test
 
 # 仅 KV 故障测试
-mvn test -pl yama-example-raft -Dtest=KvRaftFaultTest,KVStateMachineTest,RaftKvRecoveryIntegrationTest
+mvn test -pl yama-example-raft -Dtest=KvRaftFaultTest,JsonKvRaftFaultTest,KVStateMachineTest,RaftKvRecoveryIntegrationTest
 
 # 仅 WAL 恢复测试
 mvn test -pl yama-raft -Dtest=RocksDBCommitLogRecoveryTest
@@ -194,6 +197,7 @@ mvn spring-boot:run -pl yama-example-raft \
 | 文件 | 说明 |
 |------|------|
 | `yama-example-raft/.../KvRaftFaultTest.java` | 多节点故障测试（内存模拟） |
+| `yama-example-raft/.../JsonKvRaftFaultTest.java` | JSON 编码值故障测试（内存模拟） |
 | `yama-example-raft/.../RaftKvFaultIntegrationTest.java` | 集成故障测试（真实 HTTP 三节点） |
 | `yama-example-raft/.../support/RaftKvClusterHarness.java` | 三节点 Spring Boot 集群管理 |
 | `yama-example-raft/.../RaftKvRecoveryIntegrationTest.java` | 重启恢复集成测试 |

--- a/yama-example-raft/src/test/java/com/song/yama/example/raft/JsonKvRaftFaultTest.java
+++ b/yama-example-raft/src/test/java/com/song/yama/example/raft/JsonKvRaftFaultTest.java
@@ -1,0 +1,121 @@
+package com.song.yama.example.raft;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import com.song.yama.example.raft.support.JsonKvTestValues;
+import com.song.yama.example.raft.support.KvRaftCluster;
+import org.junit.Test;
+
+/**
+ * Fault tests verifying JSON-encoded KV payloads stay consistent under network failures.
+ */
+public class JsonKvRaftFaultTest {
+
+    @Test
+    public void unicodeValuesSurviveReplication() {
+        KvRaftCluster cluster = KvRaftCluster.newCluster(3);
+        cluster.electLeader(1);
+        cluster.put(1, "unicode", JsonKvTestValues.UNICODE_VALUE);
+        cluster.sync();
+        cluster.assertKvConsistent("unicode", JsonKvTestValues.UNICODE_VALUE);
+    }
+
+    @Test
+    public void specialCharactersSurvivePartitionHeal() {
+        KvRaftCluster cluster = KvRaftCluster.newCluster(3);
+        cluster.electLeader(1);
+        cluster.put(1, "quoted", JsonKvTestValues.QUOTED_VALUE);
+        cluster.sync();
+
+        cluster.isolate(2);
+        cluster.put(1, "escaped", JsonKvTestValues.ESCAPED_VALUE);
+        cluster.sync();
+
+        assertEquals(JsonKvTestValues.ESCAPED_VALUE, cluster.node(1).getKv().lookup("escaped"));
+        assertNull(cluster.node(2).getKv().lookup("escaped"));
+
+        cluster.recover();
+        cluster.heartbeat(1);
+        cluster.sync();
+
+        cluster.assertKvConsistent("quoted", JsonKvTestValues.QUOTED_VALUE);
+        cluster.assertKvConsistent("escaped", JsonKvTestValues.ESCAPED_VALUE);
+    }
+
+    @Test
+    public void jsonLikeValueSurvivesLeaderFailover() {
+        KvRaftCluster cluster = KvRaftCluster.newCluster(3);
+        cluster.electLeader(1);
+        cluster.put(1, "payload", JsonKvTestValues.JSON_LIKE_VALUE);
+        cluster.sync();
+
+        cluster.isolate(1);
+        cluster.electLeader(2);
+        cluster.put(2, "unicode", JsonKvTestValues.UNICODE_VALUE);
+        cluster.sync();
+
+        assertEquals(JsonKvTestValues.JSON_LIKE_VALUE, cluster.node(2).getKv().lookup("payload"));
+        assertEquals(JsonKvTestValues.UNICODE_VALUE, cluster.node(3).getKv().lookup("unicode"));
+    }
+
+    @Test
+    public void emptyValueSurvivesAsymmetricDrop() {
+        KvRaftCluster cluster = KvRaftCluster.newCluster(3);
+        cluster.electLeader(1);
+        cluster.put(1, "seed", "v0");
+        cluster.sync();
+
+        cluster.drop(1, 2, 2.0f);
+        cluster.drop(1, 3, 2.0f);
+        cluster.put(1, "empty", JsonKvTestValues.EMPTY_VALUE);
+        cluster.sync();
+
+        assertEquals(JsonKvTestValues.EMPTY_VALUE, cluster.node(1).getKv().lookup("empty"));
+        assertNull(cluster.node(2).getKv().lookup("empty"));
+        assertNull(cluster.node(3).getKv().lookup("empty"));
+    }
+
+    @Test
+    public void manySpecialJsonWritesStayConsistent() {
+        KvRaftCluster cluster = KvRaftCluster.newCluster(3);
+        cluster.electLeader(1);
+
+        String[] values = {
+            JsonKvTestValues.UNICODE_VALUE,
+            JsonKvTestValues.QUOTED_VALUE,
+            JsonKvTestValues.ESCAPED_VALUE,
+            JsonKvTestValues.JSON_LIKE_VALUE,
+            JsonKvTestValues.EMPTY_VALUE
+        };
+
+        for (int i = 0; i < values.length; i++) {
+            cluster.put(1, "json-" + i, values[i]);
+        }
+        cluster.sync();
+
+        for (int i = 0; i < values.length; i++) {
+            cluster.assertKvConsistent("json-" + i, values[i]);
+        }
+    }
+
+    @Test
+    public void oldLeaderRejoinsJsonValuesConverge() {
+        KvRaftCluster cluster = KvRaftCluster.newCluster(3);
+        cluster.electLeader(1);
+        cluster.put(1, "a", JsonKvTestValues.QUOTED_VALUE);
+        cluster.sync();
+
+        cluster.isolate(1);
+        cluster.electLeader(2);
+        cluster.put(2, "b", JsonKvTestValues.ESCAPED_VALUE);
+        cluster.sync();
+
+        cluster.recover();
+        cluster.heartbeat(2);
+        cluster.sync();
+
+        cluster.assertKvConsistent("a", JsonKvTestValues.QUOTED_VALUE);
+        cluster.assertKvConsistent("b", JsonKvTestValues.ESCAPED_VALUE);
+    }
+}

--- a/yama-example-raft/src/test/java/com/song/yama/example/raft/KVStateMachineTest.java
+++ b/yama-example-raft/src/test/java/com/song/yama/example/raft/KVStateMachineTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import com.alibaba.fastjson.JSONObject;
+import com.song.yama.example.raft.support.JsonKvTestValues;
 import com.song.yama.example.raft.support.TestKvStateMachine;
 import com.song.yama.raft.protobuf.RaftProtoBuf.Entry;
 import com.song.yama.raft.protobuf.RaftProtoBuf.EntryType;
@@ -69,5 +70,46 @@ public class KVStateMachineTest {
         sm.processCommits(json.toJSONString());
         assertNotNull(sm.lookup("name"));
         assertNull(sm.lookup("missing"));
+    }
+
+    @Test
+    public void unicodeAndSpecialCharsRoundTrip() {
+        TestKvStateMachine sm = new TestKvStateMachine();
+        sm.processCommits(buildCommit("unicode", JsonKvTestValues.UNICODE_VALUE));
+        sm.processCommits(buildCommit("quoted", JsonKvTestValues.QUOTED_VALUE));
+        sm.processCommits(buildCommit("escaped", JsonKvTestValues.ESCAPED_VALUE));
+        sm.processCommits(buildCommit("json-like", JsonKvTestValues.JSON_LIKE_VALUE));
+        sm.processCommits(buildCommit("empty", JsonKvTestValues.EMPTY_VALUE));
+
+        assertEquals(JsonKvTestValues.UNICODE_VALUE, sm.lookup("unicode"));
+        assertEquals(JsonKvTestValues.QUOTED_VALUE, sm.lookup("quoted"));
+        assertEquals(JsonKvTestValues.ESCAPED_VALUE, sm.lookup("escaped"));
+        assertEquals(JsonKvTestValues.JSON_LIKE_VALUE, sm.lookup("json-like"));
+        assertEquals(JsonKvTestValues.EMPTY_VALUE, sm.lookup("empty"));
+    }
+
+    @Test
+    public void snapshotPreservesSpecialJsonValues() {
+        TestKvStateMachine sm = new TestKvStateMachine();
+        sm.processCommits(buildCommit("unicode", JsonKvTestValues.UNICODE_VALUE));
+        sm.processCommits(buildCommit("escaped", JsonKvTestValues.ESCAPED_VALUE));
+
+        byte[] data = sm.getSnapshot();
+        Snapshot snapshot = Snapshot.newBuilder()
+            .setMetadata(SnapshotMetadata.newBuilder().setIndex(3).setTerm(1).build())
+            .setData(com.google.protobuf.ByteString.copyFrom(data))
+            .build();
+
+        TestKvStateMachine restored = new TestKvStateMachine();
+        restored.loadSnapshot(snapshot);
+        assertEquals(JsonKvTestValues.UNICODE_VALUE, restored.lookup("unicode"));
+        assertEquals(JsonKvTestValues.ESCAPED_VALUE, restored.lookup("escaped"));
+    }
+
+    private static String buildCommit(String key, String value) {
+        JSONObject json = new JSONObject();
+        json.put("key", key);
+        json.put("value", value);
+        return json.toJSONString();
     }
 }

--- a/yama-example-raft/src/test/java/com/song/yama/example/raft/RaftKvFaultIntegrationTest.java
+++ b/yama-example-raft/src/test/java/com/song/yama/example/raft/RaftKvFaultIntegrationTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.fail;
 
 import com.song.yama.example.raft.support.FaultInjectionRegistry;
+import com.song.yama.example.raft.support.JsonKvTestValues;
 import com.song.yama.example.raft.support.RaftKvClusterHarness;
 import com.song.yama.example.raft.support.RaftKvHttpClient;
 import org.junit.After;
@@ -247,6 +248,44 @@ public class RaftKvFaultIntegrationTest {
         FaultInjectionRegistry.recover();
         Thread.sleep(2000);
         client.waitFor(cluster.node(followerId).getPort(), "blocked", "yes", 80);
+    }
+
+    @Test
+    public void specialJsonValuesReplicateOverHttp() throws Exception {
+        cluster = RaftKvClusterHarness.startThreeNodeCluster();
+        cluster.putOnLeader(client, "unicode", JsonKvTestValues.UNICODE_VALUE);
+        cluster.putOnLeader(client, "quoted", JsonKvTestValues.QUOTED_VALUE);
+        cluster.putOnLeader(client, "escaped", JsonKvTestValues.ESCAPED_VALUE);
+        cluster.putOnLeader(client, "json-like", JsonKvTestValues.JSON_LIKE_VALUE);
+
+        cluster.assertKvConsistent(client, "unicode", JsonKvTestValues.UNICODE_VALUE);
+        cluster.assertKvConsistent(client, "quoted", JsonKvTestValues.QUOTED_VALUE);
+        cluster.assertKvConsistent(client, "escaped", JsonKvTestValues.ESCAPED_VALUE);
+        cluster.assertKvConsistent(client, "json-like", JsonKvTestValues.JSON_LIKE_VALUE);
+    }
+
+    @Test
+    public void specialJsonValuesConvergeAfterPartition() throws Exception {
+        cluster = RaftKvClusterHarness.startThreeNodeCluster();
+        int leaderId = cluster.leaderId();
+        cluster.putOnLeader(client, "seed", "v0");
+
+        int isolatedId = 1;
+        while (isolatedId == leaderId) {
+            isolatedId++;
+        }
+
+        FaultInjectionRegistry.isolate(isolatedId);
+        client.put(cluster.leaderPort(), "unicode", JsonKvTestValues.UNICODE_VALUE);
+        client.put(cluster.leaderPort(), "escaped", JsonKvTestValues.ESCAPED_VALUE);
+        Thread.sleep(1500);
+
+        client.waitForReadUnavailable(cluster.node(isolatedId).getPort(), "unicode", 30);
+
+        FaultInjectionRegistry.recover();
+        Thread.sleep(2000);
+        cluster.assertKvConsistent(client, "unicode", JsonKvTestValues.UNICODE_VALUE);
+        cluster.assertKvConsistent(client, "escaped", JsonKvTestValues.ESCAPED_VALUE);
     }
 
     private int countLeaders() {

--- a/yama-example-raft/src/test/java/com/song/yama/example/raft/support/JsonKvTestValues.java
+++ b/yama-example-raft/src/test/java/com/song/yama/example/raft/support/JsonKvTestValues.java
@@ -1,0 +1,16 @@
+package com.song.yama.example.raft.support;
+
+/**
+ * Sample KV payloads that stress JSON encoding under Raft fault scenarios.
+ */
+public final class JsonKvTestValues {
+
+    public static final String UNICODE_VALUE = "中文-emoji-🚀";
+    public static final String QUOTED_VALUE = "say \"hello\" and 'world'";
+    public static final String ESCAPED_VALUE = "line1\nline2\ttab\\backslash";
+    public static final String JSON_LIKE_VALUE = "{\"nested\":\"value\",\"n\":42}";
+    public static final String EMPTY_VALUE = "";
+
+    private JsonKvTestValues() {
+    }
+}

--- a/yama-example-raft/src/test/java/com/song/yama/example/raft/support/RaftKvHttpClient.java
+++ b/yama-example-raft/src/test/java/com/song/yama/example/raft/support/RaftKvHttpClient.java
@@ -2,22 +2,22 @@ package com.song.yama.example.raft.support;
 
 import static org.junit.Assert.assertEquals;
 
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
+import java.net.URI;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
 
 public final class RaftKvHttpClient {
 
     private final RestTemplate restTemplate = new RestTemplate();
 
     public void put(int port, String key, String value) throws InterruptedException {
-        String body = restTemplate.getForObject(url(port, "/put?key=" + encode(key) + "&value=" + encode(value)), String.class);
+        String body = restTemplate.getForObject(putUri(port, key, value), String.class);
         assertEquals("ok", body);
         waitFor(port, key, value, 50);
     }
 
     public String get(int port, String key) {
-        return restTemplate.getForObject(url(port, "/get?key=" + encode(key)), String.class);
+        return restTemplate.getForObject(getUri(port, key), String.class);
     }
 
     public boolean isReadUnavailable(int port, String key) {
@@ -52,15 +52,28 @@ public final class RaftKvHttpClient {
         assertEquals(expected, get(port, key));
     }
 
-    private static String url(int port, String path) {
-        return "http://127.0.0.1:" + port + "/yama/raft/api/v1" + path;
+    private static URI putUri(int port, String key, String value) {
+        return UriComponentsBuilder
+            .fromHttpUrl(baseUrl(port))
+            .path("/put")
+            .queryParam("key", key)
+            .queryParam("value", value)
+            .build()
+            .encode()
+            .toUri();
     }
 
-    private static String encode(String value) {
-        try {
-            return URLEncoder.encode(value, StandardCharsets.UTF_8.name());
-        } catch (java.io.UnsupportedEncodingException e) {
-            throw new IllegalStateException(e);
-        }
+    private static URI getUri(int port, String key) {
+        return UriComponentsBuilder
+            .fromHttpUrl(baseUrl(port))
+            .path("/get")
+            .queryParam("key", key)
+            .build()
+            .encode()
+            .toUri();
+    }
+
+    private static String baseUrl(int port) {
+        return "http://127.0.0.1:" + port + "/yama/raft/api/v1";
     }
 }

--- a/yama-example-raft/src/test/java/com/song/yama/example/raft/support/RaftKvHttpClient.java
+++ b/yama-example-raft/src/test/java/com/song/yama/example/raft/support/RaftKvHttpClient.java
@@ -43,9 +43,15 @@ public final class RaftKvHttpClient {
 
     public void waitFor(int port, String key, String expected, int attempts) throws InterruptedException {
         for (int i = 0; i < attempts; i++) {
-            String actual = get(port, key);
-            if (expected == null ? actual == null : expected.equals(actual)) {
-                return;
+            try {
+                String actual = get(port, key);
+                if (expected == null ? actual == null : expected.equals(actual)) {
+                    return;
+                }
+            } catch (org.springframework.web.client.HttpServerErrorException e) {
+                if (e.getRawStatusCode() != 503) {
+                    throw e;
+                }
             }
             Thread.sleep(100);
         }

--- a/yama-example-raft/src/test/java/com/song/yama/example/raft/support/RaftKvHttpClient.java
+++ b/yama-example-raft/src/test/java/com/song/yama/example/raft/support/RaftKvHttpClient.java
@@ -2,6 +2,8 @@ package com.song.yama.example.raft.support;
 
 import static org.junit.Assert.assertEquals;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import org.springframework.web.client.RestTemplate;
 
 public final class RaftKvHttpClient {
@@ -9,13 +11,13 @@ public final class RaftKvHttpClient {
     private final RestTemplate restTemplate = new RestTemplate();
 
     public void put(int port, String key, String value) throws InterruptedException {
-        String body = restTemplate.getForObject(url(port, "/put?key=" + key + "&value=" + value), String.class);
+        String body = restTemplate.getForObject(url(port, "/put?key=" + encode(key) + "&value=" + encode(value)), String.class);
         assertEquals("ok", body);
         waitFor(port, key, value, 50);
     }
 
     public String get(int port, String key) {
-        return restTemplate.getForObject(url(port, "/get?key=" + key), String.class);
+        return restTemplate.getForObject(url(port, "/get?key=" + encode(key)), String.class);
     }
 
     public boolean isReadUnavailable(int port, String key) {
@@ -52,5 +54,13 @@ public final class RaftKvHttpClient {
 
     private static String url(int port, String path) {
         return "http://127.0.0.1:" + port + "/yama/raft/api/v1" + path;
+    }
+
+    private static String encode(String value) {
+        try {
+            return URLEncoder.encode(value, StandardCharsets.UTF_8.name());
+        } catch (java.io.UnsupportedEncodingException e) {
+            throw new IllegalStateException(e);
+        }
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

为 KV Raft 状态机的 JSON 编解码增加故障测试，验证 Unicode、转义字符、类 JSON 字符串等边界值在网络分区、Leader 切换、非对称丢包等场景下仍能正确复制与收敛。

## Changes

- 新增 `JsonKvRaftFaultTest`（6 个内存模拟用例）
- 新增 `JsonKvTestValues` 共享测试载荷
- 扩展 `KVStateMachineTest`：特殊 JSON 往返与快照恢复
- 在 `RaftKvFaultIntegrationTest` 中增加 2 个 HTTP 集成用例
- 修复 `RaftKvHttpClient`：使用 `UriComponentsBuilder` + `URI` 避免双重 URL 编码
- 更新 `docs/kv-raft-fault-testing.md`

## Test plan

- [x] `mvn test -pl yama-example-raft -Dtest=JsonKvRaftFaultTest,KVStateMachineTest`
- [x] `mvn test -pl yama-example-raft -Dtest=RaftKvFaultIntegrationTest#specialJsonValuesReplicateOverHttp,RaftKvFaultIntegrationTest#specialJsonValuesConvergeAfterPartition`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f204e-e901-7aac-ac6f-8e7a0d8816b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f204e-e901-7aac-ac6f-8e7a0d8816b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

